### PR TITLE
feat: align frontend with refactored backend API

### DIFF
--- a/src/components/LatestBlocksTable.tsx
+++ b/src/components/LatestBlocksTable.tsx
@@ -1,81 +1,61 @@
 "use client";
 
 import React from 'react';
-import { usePaginatedApiData } from '../hooks/useApiData';
+import { useApiData } from '../hooks/useApiData';
 import { api } from '../lib/api';
 import { Block, LatestBlocksResponse } from '../types';
 import DataStateWrapper from './DataStateWrapper';
 import { useNetwork } from '../hooks/useNetwork';
 
 export default function LatestBlocksTable() {
-  const itemsPerPage = 5;
   const { selectedNetwork } = useNetwork();
 
-  // Fetch latest blocks data with pagination
-  const {
-    data,
-    isLoading,
-    error,
-    pagination: { page, nextPage, prevPage }
-  } = usePaginatedApiData<LatestBlocksResponse>(
-    (page, limit, network) => api.getLatestBlocks(page, limit, network),
-    [selectedNetwork],
-    selectedNetwork.apiParam
+  const { data, isLoading, error } = useApiData<LatestBlocksResponse>(
+    () => api.getLatestBlocks(20, selectedNetwork.apiParam),
+    [selectedNetwork]
   );
 
   // Loading state for the table
   const loadingComponent = (
-    <>
-      <div className="overflow-x-auto border border-divider rounded-lg">
-        <table className="min-w-full overflow-hidden table-fixed">
-          <thead>
-            <tr className="border-b border-divider bg-gradient-to-b from-[#22252c] to-[#16171b]">
-              <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-1/5">Block</th>
-              <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-1/6">Blobs</th>
-              <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-1/4 whitespace-nowrap">Time</th>
-              <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-2/5">Attribution</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-divider">
-            {[...Array(5)].map((_, index) => (
-              <tr key={index} className="bg-gradient-to-r from-[#161a29] to-[#19191e]/60">
-                <td className="py-3 px-6">
-                  <div className="h-5 bg-[#202538] rounded w-24 animate-pulse"></div>
-                </td>
-                <td className="py-3 px-6">
-                  <div className="h-5 bg-[#202538] rounded w-8 animate-pulse"></div>
-                </td>
-                <td className="py-3 px-6">
-                  <div className="h-5 bg-[#202538] rounded w-20 animate-pulse"></div>
-                </td>
-                <td className="py-3 px-6">
-                  <div className="flex items-center">
-                    <div className="flex -space-x-2">
-                      {[...Array(3)].map((_, idx) => (
-                        <div
-                          key={idx}
-                          className="inline-block w-5 h-5 rounded-full bg-[#202538] animate-pulse"
-                        />
-                      ))}
-                    </div>
+    <div className="overflow-x-auto border border-divider rounded-lg">
+      <table className="min-w-full overflow-hidden table-fixed">
+        <thead>
+          <tr className="border-b border-divider bg-gradient-to-b from-[#22252c] to-[#16171b]">
+            <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-1/5">Block</th>
+            <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-1/6">Blobs</th>
+            <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-1/4 whitespace-nowrap">Time</th>
+            <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-2/5">Attribution</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-divider">
+          {[...Array(5)].map((_, index) => (
+            <tr key={index} className="bg-gradient-to-r from-[#161a29] to-[#19191e]/60">
+              <td className="py-3 px-6">
+                <div className="h-5 bg-[#202538] rounded w-24 animate-pulse"></div>
+              </td>
+              <td className="py-3 px-6">
+                <div className="h-5 bg-[#202538] rounded w-8 animate-pulse"></div>
+              </td>
+              <td className="py-3 px-6">
+                <div className="h-5 bg-[#202538] rounded w-20 animate-pulse"></div>
+              </td>
+              <td className="py-3 px-6">
+                <div className="flex items-center">
+                  <div className="flex -space-x-2">
+                    {[...Array(3)].map((_, idx) => (
+                      <div
+                        key={idx}
+                        className="inline-block w-5 h-5 rounded-full bg-[#202538] animate-pulse"
+                      />
+                    ))}
                   </div>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      <div className="flex justify-between items-center mt-6">
-        <div className="text-sm text-[#6e7787]">
-          <div className="h-5 bg-[#202538] rounded w-40 animate-pulse"></div>
-        </div>
-        <div className="flex space-x-3">
-          <div className="h-8 bg-[#202538] rounded w-20 animate-pulse"></div>
-          <div className="h-8 bg-[#202538] rounded w-20 animate-pulse"></div>
-        </div>
-      </div>
-    </>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 
   return (
@@ -88,83 +68,56 @@ export default function LatestBlocksTable() {
         loadingComponent={loadingComponent}
       >
         {data && (
-          <>
-            <div className="overflow-x-auto border border-divider rounded-lg">
-              <table className="min-w-full overflow-hidden table-fixed">
-                <thead>
-                  <tr className="border-b border-divider bg-gradient-to-b from-[#22252c] to-[#16171b]">
-                    <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-1/5">Block</th>
-                    <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-1/6">Blobs</th>
-                    <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-1/4 whitespace-nowrap">Time</th>
-                    <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-2/5">Attribution</th>
+          <div className="overflow-x-auto border border-divider rounded-lg">
+            <table className="min-w-full overflow-hidden table-fixed">
+              <thead>
+                <tr className="border-b border-divider bg-gradient-to-b from-[#22252c] to-[#16171b]">
+                  <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-1/5">Block</th>
+                  <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-1/6">Blobs</th>
+                  <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-1/4 whitespace-nowrap">Time</th>
+                  <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-2/5">Attribution</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-divider">
+                {data.data.map((block: Block) => (
+                  <tr key={block.id} className="bg-gradient-to-r from-[#161a29] to-[#19191e]/60 hover:bg-gradient-to-r hover:from-[#202538]/70 hover:to-[#242731]/70 transition-colors">
+                    <td className="py-3 px-6 text-sm font-medium text-white">{block.number}</td>
+                    <td className="py-3 px-6 text-sm text-white">{block.blobCount}</td>
+                    <td className="py-3 px-6 text-sm text-white whitespace-nowrap">{block.timestamp}</td>
+                    <td className="py-3 px-6 text-sm text-white">
+                      {block.attribution.length === 1 ? (
+                        <div className="flex items-center">
+                          <img
+                            src={`/images/${block.attribution[0].toLowerCase()}.png`}
+                            alt={block.attribution[0]}
+                            className="inline-block w-5 h-5 mr-2"
+                          />
+                          <span className="whitespace-nowrap">{block.attribution[0]}</span>
+                        </div>
+                      ) : (
+                        <div className="flex items-center">
+                          <div className="flex -space-x-2">
+                            {block.attribution.map((attr, idx) => (
+                              <img
+                                key={idx}
+                                src={`/images/${attr.toLowerCase()}.png`}
+                                alt={attr}
+                                className="inline-block w-5 h-5 rounded-full ring-1 ring-gray-800 min-w-[1.25rem] min-h-[1.25rem]"
+                                title={attr}
+                              />
+                            ))}
+                          </div>
+                          <span className="whitespace-nowrap text-sm text-white ml-6">
+                            {block.attribution.length} networks
+                          </span>
+                        </div>
+                      )}
+                    </td>
                   </tr>
-                </thead>
-                <tbody className="divide-y divide-divider">
-                  {data.data.map((block: Block) => (
-                    <tr key={block.id} className="bg-gradient-to-r from-[#161a29] to-[#19191e]/60 hover:bg-gradient-to-r hover:from-[#202538]/70 hover:to-[#242731]/70 transition-colors">
-                      <td className="py-3 px-6 text-sm font-medium text-white">{block.number}</td>
-                      <td className="py-3 px-6 text-sm text-white">{block.blobCount}</td>
-                      <td className="py-3 px-6 text-sm text-white whitespace-nowrap">{block.timestamp}</td>
-                      <td className="py-3 px-6 text-sm text-white">
-                        {block.attribution.length === 1 ? (
-                          <div className="flex items-center">
-                            <img
-                              src={`/images/${block.attribution[0].toLowerCase()}.png`}
-                              alt={block.attribution[0]}
-                              className="inline-block w-5 h-5 mr-2"
-                            />
-                            <span className="whitespace-nowrap">{block.attribution[0]}</span>
-                          </div>
-                        ) : (
-                          <div className="flex items-center">
-                            <div className="flex -space-x-2">
-                              {block.attribution.map((attr, idx) => (
-                                <img
-                                  key={idx}
-                                  src={`/images/${attr.toLowerCase()}.png`}
-                                  alt={attr}
-                                  className="inline-block w-5 h-5 rounded-full ring-1 ring-gray-800 min-w-[1.25rem] min-h-[1.25rem]"
-                                  title={attr}
-                                />
-                              ))}
-                            </div>
-                            <span className="whitespace-nowrap text-sm text-white ml-6">
-                              {block.attribution.length} networks
-                            </span>
-                          </div>
-                        )}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-
-            {/* Pagination controls */}
-            <div className="flex justify-between items-center mt-6">
-              <div className="text-sm text-[#6e7787]">
-                Showing {data.pagination.currentPage > 0 && data.data.length > 0
-                  ? `${(data.pagination.currentPage - 1) * itemsPerPage + 1}-${(data.pagination.currentPage - 1) * itemsPerPage + data.data.length}`
-                  : '0'} of {data.pagination.totalItems}
-              </div>
-              <div className="flex space-x-3">
-                <button
-                  onClick={prevPage}
-                  disabled={page === 1}
-                  className="px-3 py-1 text-sm rounded-md bg-[#1d1f23] text-white border border-divider border-b-[#282a2f] border-b-2 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  Previous
-                </button>
-                <button
-                  onClick={nextPage}
-                  disabled={page >= data.pagination.totalPages}
-                  className="px-3 py-1 text-sm rounded-md bg-[#1d1f23] text-white border border-divider border-b-[#282a2f] border-b-2 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  Next
-                </button>
-              </div>
-            </div>
-          </>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </DataStateWrapper>
     </section>

--- a/src/components/LiveMetrics.tsx
+++ b/src/components/LiveMetrics.tsx
@@ -13,7 +13,7 @@ export default function LiveMetrics() {
 
   // Fetch stats data from API
   const { data, isLoading, error } = useApiData<StatsResponse>(
-    () => api.getStats(undefined, selectedNetwork.apiParam),
+    () => api.getStats(selectedNetwork.apiParam),
     [selectedNetwork]
   );
 
@@ -21,18 +21,12 @@ export default function LiveMetrics() {
   const getMetricsFromData = (statsData: StatsResponse) => {
     const stats = statsData.data;
 
-    // Explicitly type the trend values to match the Metric interface
-    const blobFeeTrend: 'up' | 'down' | 'neutral' =
-      stats.blobBaseFeeChange > 0 ? 'up' :
-        stats.blobBaseFeeChange < 0 ? 'down' : 'neutral';
-
-    // Return metrics with trend direction calculated from data
     return [
       {
-        title: 'Current Blob Base Fee',
-        value: stats.currentBlobBaseFee,
-        trend: blobFeeTrend,
-        description: `Hourly change: ${stats.blobBaseFeeChange > 0 ? '+' : ''}${stats.blobBaseFeeChange.toFixed(1)}%`,
+        title: 'Avg Blob Base Fee',
+        value: stats.averageBaseFee,
+        trend: 'neutral' as const,
+        description: `${stats.totalConfirmedBlobs} confirmed blobs`,
         icon: 'fa-regular fa-money-bills'
       },
       {
@@ -43,17 +37,17 @@ export default function LiveMetrics() {
         icon: 'fa-regular fa-timer'
       },
       {
-        title: 'Avg. Blobs per Block (24h)',
-        value: stats.avgBlobsPerBlock.toString(),
+        title: 'Total Blobs Indexed',
+        value: stats.totalBlobs.toLocaleString(),
         trend: 'neutral' as const,
-        description: '24h network average',
+        description: `Last block: ${stats.lastIndexedBlock.toLocaleString()}`,
         icon: 'fa-regular fa-cube'
       },
       {
-        title: 'Blob Cost vs Calldata Cost',
-        value: stats.blobVsCalldataSavings,
-        trend: 'down' as const,
-        description: 'Savings vs calldata',
+        title: 'Avg Total Cost',
+        value: stats.averageTotalCost,
+        trend: 'neutral' as const,
+        description: `Avg tip: ${stats.averageTip}`,
         icon: 'fa-regular fa-scale-unbalanced-flip'
       }
     ];

--- a/src/components/MempoolTable.tsx
+++ b/src/components/MempoolTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from 'react';
-import { usePaginatedApiData } from '../hooks/useApiData';
+import { useApiData } from '../hooks/useApiData';
 import { api } from '../lib/api';
 import { MempoolResponse, MempoolTransaction } from '../types';
 import DataStateWrapper from './DataStateWrapper';
@@ -10,15 +10,9 @@ import { useNetwork } from '../hooks/useNetwork';
 export default function MempoolTable() {
   const { selectedNetwork } = useNetwork();
 
-  // Fetch mempool data with pagination
-  const {
-    data,
-    isLoading,
-    error,
-  } = usePaginatedApiData<MempoolResponse>(
-    (page, limit, network) => api.getMempool(page, limit, network),
-    [selectedNetwork],
-    selectedNetwork.apiParam
+  const { data, isLoading, error } = useApiData<MempoolResponse>(
+    () => api.getMempool(10, selectedNetwork.apiParam),
+    [selectedNetwork]
   );
 
   // Loading state for the table

--- a/src/components/TopUsersTable.tsx
+++ b/src/components/TopUsersTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect } from 'react';
-import { usePaginatedApiData } from '../hooks/useApiData';
+import { useApiData } from '../hooks/useApiData';
 import { api } from '../lib/api';
 import { TopUsersResponse, User } from '../types';
 import DataStateWrapper from './DataStateWrapper';
@@ -14,15 +14,9 @@ interface TopUsersTableProps {
 export default function TopUsersTable({ onUserClick }: TopUsersTableProps) {
   const { selectedNetwork } = useNetwork();
 
-  // Fetch top users data with pagination
-  const {
-    data,
-    isLoading,
-    error,
-  } = usePaginatedApiData<TopUsersResponse>(
-    (page, limit, network) => api.getTopUsers(page, limit, network),
-    [selectedNetwork],
-    selectedNetwork.apiParam
+  const { data, isLoading, error } = useApiData<TopUsersResponse>(
+    () => api.getTopUsers(10, selectedNetwork.apiParam),
+    [selectedNetwork]
   );
 
   useEffect(() => {
@@ -54,7 +48,7 @@ export default function TopUsersTable({ onUserClick }: TopUsersTableProps) {
             fontSize: '12px',
             boxShadow: '0 1px 8px rgba(0,0,0,0.5)',
             border: '1px solid #333',
-            zIndex: '99999999', // Super high z-index
+            zIndex: '99999999',
             pointerEvents: 'none',
             whiteSpace: 'nowrap',
             opacity: '1',
@@ -224,7 +218,7 @@ export default function TopUsersTable({ onUserClick }: TopUsersTableProps) {
                   >
                     <td className="py-3 px-6 text-sm font-medium text-white whitespace-nowrap">
                       <div className="flex items-center">
-                        {user.name === 'Unknown' ? (
+                        {user.name === 'Unknown' || user.name.includes('...') ? (
                           <span className="inline-block w-5 h-5 rounded-full mr-3 bg-gray-500"></span>
                         ) : (
                           <img

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,7 +3,7 @@
  */
 
 export const APP_NAME = 'Blob Flow';
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://blob-indexer.ahkc.win/api';
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://blob-indexer.ahkc.win/api/v1';
 
 /**
  * Network configuration

--- a/src/lib/api/blocks.ts
+++ b/src/lib/api/blocks.ts
@@ -1,94 +1,42 @@
-import { Block, LatestBlocksResponse } from '../../types';
+import { Block, LatestBlocksResponse, ApiResponse, BlobResponse } from '../../types';
 import { fetchApi, formatRelativeTime } from './core';
 
 /**
- * Get latest blocks with pagination
- * @param page - Page number (starts at 1)
- * @param limit - Number of items per page
+ * Get latest confirmed blobs and group them by block
+ * @param limit - Number of blobs to fetch
  * @param network - Optional network parameter
  */
-export async function getLatestBlocks(page = 1, limit = 10, network?: string): Promise<LatestBlocksResponse> {
-    // Convert page-based pagination to cursor-based pagination
-    // For the first page, we don't need a cursor
-    const cursor = page > 1 ? `page_${page}` : '';
+export async function getLatestBlocks(limit = 20, network?: string): Promise<LatestBlocksResponse> {
+    const response = await fetchApi<ApiResponse<BlobResponse[]>>(`/blob/latest?limit=${limit}`, network);
 
-    const response = await fetchApi<any>(`/blob/latest?limit=${limit}${cursor ? `&cursor=${cursor}` : ''}`, network);
+    // Group blobs by block number
+    const blockMap = new Map<string, { blobs: BlobResponse[]; firstSeen: string }>();
+    for (const blob of response.data) {
+        const blockNum = blob.block_number.toString();
+        if (!blockMap.has(blockNum)) {
+            blockMap.set(blockNum, { blobs: [], firstSeen: blob.timestamp });
+        }
+        blockMap.get(blockNum)!.blobs.push(blob);
+    }
 
-    // Map the API response to our expected format
-    const blocks: Block[] = response.data.map((blob: any, index: number) => {
-        // Group blobs by block number
-        const blockNumber = blob.block_number.toString();
-
-        // Count blobs in this block
-        const blobCount = response.data.filter((b: any) => b.block_number.toString() === blockNumber).length;
-
-        // Get unique attributions for this block
+    // Convert to Block[] for display
+    const blocks: Block[] = Array.from(blockMap.entries()).map(([blockNum, { blobs, firstSeen }], index) => {
         const attributions: string[] = Array.from(new Set(
-            response.data
-                .filter((b: any) => b.block_number.toString() === blockNumber)
-                .map((b: any) => b.user_attribution as string)
-                .filter(Boolean)
+            blobs
+                .map(b => b.user_attribution)
+                .filter((attr): attr is string => Boolean(attr))
         ));
 
         return {
             id: index + 1,
-            number: blockNumber,
-            blobCount,
-            timestamp: formatRelativeTime(blob.timestamp),
+            number: blockNum,
+            blobCount: blobs.length,
+            timestamp: formatRelativeTime(firstSeen),
             attribution: attributions.length > 0 ? attributions : ['Unknown']
         };
     });
 
-    // Remove duplicate blocks (since we're getting blob-level data)
-    const uniqueBlocks = blocks.filter((block, index, self) =>
-        index === self.findIndex((b) => b.number === block.number)
-    );
-
-    return {
-        data: uniqueBlocks,
-        pagination: {
-            currentPage: page,
-            totalPages: Math.ceil(response.pagination.total_items / limit),
-            totalItems: response.pagination.total_items,
-            itemsPerPage: limit
-        }
-    };
-}
-
-/**
- * Get specific block by number
- * @param blockNumber - Block number to retrieve
- * @param network - Optional network parameter
- */
-export async function getBlockByNumber(blockNumber: string, network?: string): Promise<{ data: Block }> {
-    // We need to query all blobs for this block number
-    const response = await fetchApi<any>(`/blob/latest?limit=100`, network);
-
-    // Filter blobs for this block
-    const blockBlobs = response.data.filter((blob: any) =>
-        blob.block_number.toString() === blockNumber
-    );
-
-    if (blockBlobs.length === 0) {
-        throw new Error(`Block ${blockNumber} not found`);
-    }
-
-    // Get unique attributions for this block
-    const attributions: string[] = Array.from(new Set(
-        blockBlobs
-            .map((blob: any) => blob.user_attribution as string)
-            .filter(Boolean)
-    ));
-
-    const block: Block = {
-        id: 1,
-        number: blockNumber,
-        blobCount: blockBlobs.length,
-        timestamp: formatRelativeTime(blockBlobs[0].timestamp),
-        attribution: attributions.length > 0 ? attributions : ['Unknown']
-    };
-
-    return { data: block };
+    return { data: blocks };
 }
 
 /**
@@ -96,6 +44,6 @@ export async function getBlockByNumber(blockNumber: string, network?: string): P
  * @param txHash - Transaction hash to retrieve
  * @param network - Optional network parameter
  */
-export async function getBlobByTxHash(txHash: string, network?: string): Promise<any> {
-    return fetchApi<any>(`/blob/${txHash}`, network);
+export async function getBlobByTxHash(txHash: string, network?: string): Promise<ApiResponse<BlobResponse>> {
+    return fetchApi<ApiResponse<BlobResponse>>(`/blob/${txHash}`, network);
 }

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,62 +1,16 @@
-import { getLatestBlocks, getBlockByNumber, getBlobByTxHash } from './blocks';
+import { getLatestBlocks, getBlobByTxHash } from './blocks';
 import { getMempool } from './mempool';
 import { getStats } from './stats';
+import { getStatus } from './status';
 import { getTopUsers, getUserById } from './users';
 
-/**
- * API methods for different endpoints with strong typing
- */
 export const api = {
-    /**
-     * Get latest blocks with pagination
-     * @param page - Page number (starts at 1)
-     * @param limit - Number of items per page
-     * @param network - Optional network parameter
-     */
     getLatestBlocks,
-
-    /**
-     * Get specific block by number
-     * @param blockNumber - Block number to retrieve
-     * @param network - Optional network parameter
-     */
-    getBlockByNumber,
-
-    /**
-     * Get specific blob transaction by hash
-     * @param txHash - Transaction hash to retrieve
-     * @param network - Optional network parameter
-     */
     getBlobByTxHash,
-
-    /**
-     * Get network stats data
-     * @param timeframe - Optional timeframe filter (24h, 7d, 30d, all)
-     * @param network - Optional network parameter
-     */
     getStats,
-
-    /**
-     * Get mempool data (pending transactions) with pagination
-     * @param page - Page number (starts at 1)
-     * @param limit - Number of items per page
-     * @param network - Optional network parameter
-     */
+    getStatus,
     getMempool,
-
-    /**
-     * Get top users data with pagination
-     * @param page - Page number (starts at 1)
-     * @param limit - Number of items per page
-     * @param network - Optional network parameter
-     */
     getTopUsers,
-
-    /**
-     * Get specific user details by ID
-     * @param userId - User ID to retrieve
-     * @param network - Optional network parameter
-     */
     getUserById,
 };
 

--- a/src/lib/api/mempool.ts
+++ b/src/lib/api/mempool.ts
@@ -1,38 +1,27 @@
-import { MempoolResponse, MempoolTransaction } from '../../types';
+import { MempoolResponse, MempoolTransaction, ApiResponse, BlobResponse } from '../../types';
 import { fetchApi, formatRelativeTime, truncateAddress } from './core';
+import { formatWeiToReadable } from '../../utils';
 
 /**
- * Get mempool data (pending transactions) with pagination
- * @param page - Page number (starts at 1)
- * @param limit - Number of items per page
+ * Get mempool data (pending blob transactions)
+ * @param limit - Number of blobs to fetch
  * @param network - Optional network parameter
  */
-export async function getMempool(page = 1, limit = 5, network?: string): Promise<MempoolResponse> {
-    // Convert page-based pagination to cursor-based pagination
-    const cursor = page > 1 ? `page_${page}` : '';
-
-    const response = await fetchApi<any>(`/blob/mempool?limit=${limit}${cursor ? `&cursor=${cursor}` : ''}`, network);
+export async function getMempool(limit = 10, network?: string): Promise<MempoolResponse> {
+    const response = await fetchApi<ApiResponse<BlobResponse[]>>(`/blob/mempool?limit=${limit}`, network);
 
     // Map the API response to our expected format
-    const transactions: MempoolTransaction[] = response.data.map((blob: any, index: number) => {
+    const transactions: MempoolTransaction[] = response.data.map((blob: BlobResponse, index: number) => {
         return {
             id: index + 1,
             txHash: blob.tx_hash,
             fromAddress: truncateAddress(blob.from_address),
             user: blob.user_attribution || null,
-            blobCount: 1, // Each blob is a separate entry in the API
-            estimatedCost: blob.total_cost_eth + ' ETH',
+            blobCount: 1,
+            estimatedCost: formatWeiToReadable(blob.total_cost_eth),
             timeInMempool: formatRelativeTime(blob.timestamp)
         };
     });
 
-    return {
-        data: transactions,
-        pagination: {
-            currentPage: page,
-            totalPages: Math.ceil(response.pagination.total_items / limit),
-            totalItems: response.pagination.total_items,
-            itemsPerPage: limit
-        }
-    };
+    return { data: transactions };
 }

--- a/src/lib/api/stats.ts
+++ b/src/lib/api/stats.ts
@@ -1,52 +1,27 @@
-import { StatsResponse } from '../../types';
+import { StatsResponse, ApiResponse, BackendStatsResponse } from '../../types';
 import { fetchApi } from './core';
 import { formatWeiToReadable } from '../../utils';
 
 /**
  * Get network stats data
- * @param timeframe - Optional timeframe filter (24h, 7d, 30d, all)
  * @param network - Optional network parameter
  */
-export async function getStats(timeframe?: '24h' | '7d' | '30d' | 'all', network?: string): Promise<StatsResponse> {
-    const response = await fetchApi<any>(`/stats`, network);
+export async function getStats(network?: string): Promise<StatsResponse> {
+    const response = await fetchApi<ApiResponse<BackendStatsResponse>>(`/stats`, network);
 
-    // Calculate blob vs calldata savings as a percentage
-    const blobVsCalldataSavings = `${Math.round((1 - (response.data.blob_vs_calldata_cost || 0.5)) * 100)}% cheaper`;
+    const stats = response.data;
 
-    // Map the API response to our expected format
     return {
         data: {
-            currentBlobBaseFee: formatWeiToReadable(response.data.current_base_fee || '0'),
-            blobBaseFeeChange: response.data.hourly_base_fee_change || 0,
-            pendingBlobsCount: response.data.total_pending_blobs || 0,
-            avgBlobsPerBlock: Math.round(((response.data.total_confirmed_blobs || 100) / 100) * 10) / 10, // Rough estimate
-            blobVsCalldataSavings,
-            timeFrames: {
-                '24h': {
-                    blobBaseFees: [],
-                    blobsPerBlock: [],
-                    costComparison: [],
-                    attribution: {}
-                },
-                '7d': {
-                    blobBaseFees: [],
-                    blobsPerBlock: [],
-                    costComparison: [],
-                    attribution: {}
-                },
-                '30d': {
-                    blobBaseFees: [],
-                    blobsPerBlock: [],
-                    costComparison: [],
-                    attribution: {}
-                },
-                'all': {
-                    blobBaseFees: [],
-                    blobsPerBlock: [],
-                    costComparison: [],
-                    attribution: {}
-                }
-            }
+            averageBaseFee: formatWeiToReadable(stats.average_base_fee || '0'),
+            totalBlobs: stats.total_blobs,
+            totalConfirmedBlobs: stats.total_confirmed_blobs,
+            pendingBlobsCount: stats.total_pending_blobs,
+            avgBlobsPerBlock: Math.round(((stats.total_confirmed_blobs || 100) / 100) * 10) / 10,
+            averageTip: formatWeiToReadable(stats.average_tip || '0'),
+            averageTotalCost: formatWeiToReadable(stats.average_total_cost || '0'),
+            lastIndexedBlock: stats.last_indexed_block,
+            lastIndexedTime: stats.last_indexed_time
         }
     };
 }

--- a/src/lib/api/status.ts
+++ b/src/lib/api/status.ts
@@ -1,0 +1,10 @@
+import { ApiResponse, StatusResponse } from '../../types';
+import { fetchApi } from './core';
+
+/**
+ * Get indexer status
+ * @param network - Optional network parameter
+ */
+export async function getStatus(network?: string): Promise<ApiResponse<StatusResponse>> {
+    return fetchApi<ApiResponse<StatusResponse>>(`/status`, network);
+}

--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -1,69 +1,56 @@
-import { TopUsersResponse, User, UserDetail } from '../../types';
-import { fetchApi, formatRelativeTime } from './core';
+import { TopUsersResponse, User, UserDetail, ApiResponse, UserResponse } from '../../types';
+import { fetchApi } from './core';
+import { truncateAddress } from '../../utils';
 
 /**
- * Get top users data with pagination
- * @param page - Page number (starts at 1)
- * @param limit - Number of items per page
+ * Get top blob users
+ * @param limit - Number of users to return
  * @param network - Optional network parameter
  */
-export async function getTopUsers(page = 1, limit = 5, network?: string): Promise<TopUsersResponse> {
-    // Convert page-based pagination to cursor-based pagination
-    const cursor = page > 1 ? `page_${page}` : '';
+export async function getTopUsers(limit = 10, network?: string): Promise<TopUsersResponse> {
+    const response = await fetchApi<ApiResponse<UserResponse[]>>(`/users?limit=${limit}`, network);
 
-    const response = await fetchApi<any>(`/users?limit=${limit}${cursor ? `&cursor=${cursor}` : ''}`, network);
-
-    // Get total blob count to calculate percentages
-    const statsResponse = await fetchApi<any>(`/stats`, network);
-    const totalBlobs = statsResponse.data.total_blobs || 1000; // Fallback value
+    // Calculate total blobs across all returned users for percentage calculation
+    const totalBlobs = response.data.reduce((sum, user) => sum + user.blob_count, 0) || 1;
 
     // Map the API response to our expected format
-    const users: User[] = response.data.map((user: any, index: number) => {
-        // Calculate percentage
+    const users: User[] = response.data.map((user: UserResponse, index: number) => {
         const percentage = Math.round((user.blob_count / totalBlobs) * 1000) / 10;
 
         return {
             id: index + 1,
-            name: user.name || (user.address ? `${user.address.substring(0, 6)}...` : 'Unknown'),
+            name: user.name || truncateAddress(user.address),
+            address: user.address,
             dataCount: user.blob_count,
-            percentage
+            percentage,
+            totalCostEth: user.total_cost_eth,
+            lastTimestamp: user.last_timestamp
         };
     });
 
-    return {
-        data: users,
-        pagination: {
-            currentPage: page,
-            totalPages: Math.ceil(response.pagination.total_items / limit),
-            totalItems: response.pagination.total_items,
-            itemsPerPage: limit
-        }
-    };
+    return { data: users };
 }
 
 /**
- * Get specific user details by ID
- * @param userId - User ID to retrieve
+ * Get specific user details by address
+ * @param userId - User index in the top users list
  * @param network - Optional network parameter
  */
 export async function getUserById(userId: number, network?: string): Promise<{ data: UserDetail }> {
-    // In a real implementation, we would fetch the user by ID
-    // For now, we'll use the top users endpoint and filter by ID
-    const topUsersResponse = await getTopUsers(1, 10, network);
+    const topUsersResponse = await getTopUsers(10, network);
     const user = topUsersResponse.data.find(u => u.id === userId);
 
     if (!user) {
         throw new Error(`User with ID ${userId} not found`);
     }
 
-    // Create the user detail object with empty transactions
     const userDetail: UserDetail = {
         ...user,
         transactions: [],
-        totalCost: '0 ETH',
+        totalCost: user.totalCostEth,
         avgCostPerBlob: '0 ETH',
         firstSeen: 'Unknown',
-        latestActivity: 'Unknown'
+        latestActivity: user.lastTimestamp
     };
 
     return { data: userDetail };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-// Metric type definition
+// Metric type definition (UI only)
 export interface Metric {
   title: string;
   value: string;
@@ -7,7 +7,33 @@ export interface Metric {
   icon?: string;
 }
 
-// Block type definition
+// Generic API response wrapper from backend
+export interface ApiResponse<T> {
+  success: boolean;
+  data: T;
+  error?: string;
+}
+
+// Backend BlobResponse - matches api.BlobResponse from swagger
+export interface BlobResponse {
+  network_id: number;
+  network_name: string;
+  block_number: number;
+  blob_index: number;
+  tx_hash: string;
+  from_address: string;
+  blob_size_bytes: number;
+  base_fee_per_blob_gas: string;
+  tip_per_blob_gas: string;
+  total_cost_eth: string;
+  timestamp: string;
+  confirmed: boolean;
+  user_attribution?: string;
+  max_fee_per_blob_gas?: string;
+  blob_gas_used?: number;
+}
+
+// Frontend Block type (transformed from BlobResponse for display)
 export interface Block {
   id: number;
   number: string;
@@ -16,21 +42,12 @@ export interface Block {
   attribution: string[];
 }
 
-// API Response interfaces for backend integration
-export interface PaginatedResponse<T> {
-  data: T[];
-  pagination: {
-    currentPage: number;
-    totalPages: number;
-    totalItems: number;
-    itemsPerPage: number;
-  };
+// Latest blocks response (frontend-shaped)
+export interface LatestBlocksResponse {
+  data: Block[];
 }
 
-// Latest blocks response
-export interface LatestBlocksResponse extends PaginatedResponse<Block> { }
-
-// Mempool transaction type
+// Mempool transaction type (transformed for display)
 export interface MempoolTransaction {
   id: number;
   txHash: string;
@@ -41,15 +58,31 @@ export interface MempoolTransaction {
   timeInMempool: string;
 }
 
-// Mempool response
-export interface MempoolResponse extends PaginatedResponse<MempoolTransaction> { }
+// Mempool response (frontend-shaped)
+export interface MempoolResponse {
+  data: MempoolTransaction[];
+}
 
-// User data type for listing
+// Backend UserResponse - matches api.UserResponse from swagger
+export interface UserResponse {
+  network_id: number;
+  network_name: string;
+  address: string;
+  name?: string;
+  blob_count: number;
+  total_cost_eth: string;
+  last_timestamp: string;
+}
+
+// Frontend User type (transformed for display)
 export interface User {
   id: number;
   name: string;
+  address: string;
   dataCount: number;
   percentage: number;
+  totalCostEth: string;
+  lastTimestamp: string;
 }
 
 // Transaction details for user detail view
@@ -70,39 +103,49 @@ export interface UserDetail extends User {
   latestActivity: string;
 }
 
-// Top users response
-export interface TopUsersResponse extends PaginatedResponse<User> { }
-
-// Stats type definitions
-export interface TimeSeriesDataPoint {
-  timestamp: string;
-  value: number;
+// Top users response (frontend-shaped)
+export interface TopUsersResponse {
+  data: User[];
 }
 
+// Backend StatsResponse - matches api.StatsResponse from swagger
+export interface BackendStatsResponse {
+  network_id: number;
+  network_name: string;
+  total_blobs: number;
+  total_confirmed_blobs: number;
+  total_pending_blobs: number;
+  average_base_fee: string;
+  average_tip: string;
+  average_total_cost: string;
+  last_indexed_block: number;
+  last_indexed_time: string;
+}
+
+// Frontend NetworkStats (transformed for display)
 export interface NetworkStats {
-  currentBlobBaseFee: string;
-  blobBaseFeeChange: number;
+  averageBaseFee: string;
+  totalBlobs: number;
+  totalConfirmedBlobs: number;
   pendingBlobsCount: number;
   avgBlobsPerBlock: number;
-  blobVsCalldataSavings: string;
-  timeFrames: {
-    '24h': TimeSeriesData;
-    '7d': TimeSeriesData;
-    '30d': TimeSeriesData;
-    'all': TimeSeriesData;
-  };
+  averageTip: string;
+  averageTotalCost: string;
+  lastIndexedBlock: number;
+  lastIndexedTime: string;
 }
 
-export interface TimeSeriesData {
-  blobBaseFees: TimeSeriesDataPoint[];
-  blobsPerBlock: TimeSeriesDataPoint[];
-  costComparison: TimeSeriesDataPoint[];
-  attribution: {
-    [network: string]: number;
-  };
-}
-
-// Stats response
+// Stats response (frontend-shaped)
 export interface StatsResponse {
   data: NetworkStats;
+}
+
+// Backend StatusResponse - matches api.StatusResponse from swagger
+export interface StatusResponse {
+  network_id: number;
+  network_name: string;
+  last_indexed_block: number;
+  indexer_version: string;
+  uptime: string;
+  last_indexed_time: string;
 }


### PR DESCRIPTION
## Summary
- Update API base URL to `/api/v1` to match backend refactor
- Fix all API service modules (blocks, mempool, users, stats) to use actual backend response shapes instead of assumed pagination/field names
- Add new `/status` endpoint integration
- Update all data-consuming components to use `useApiData` instead of broken `usePaginatedApiData` (backend doesn't return pagination metadata)
- Add properly typed `BlobResponse`, `BackendStatsResponse`, `UserResponse`, `StatusResponse` matching swagger spec

## Test plan
- [ ] Verify Live Metrics cards render with real data (avg base fee, pending blobs, total indexed, avg cost)
- [ ] Verify Latest Blocks table populates from `/blob/latest`
- [ ] Verify Mempool table populates from `/blob/mempool`
- [ ] Verify Top Users table populates from `/users`
- [ ] Confirm no console errors from undefined pagination properties