### PR TITLE
feat: replace placeholder charts with live blob data

### DIFF
--- a/src/components/BlobGraphs.tsx
+++ b/src/components/BlobGraphs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
   LineChart,
   Line,
@@ -11,39 +11,18 @@ import {
   Legend,
   ResponsiveContainer
 } from 'recharts';
-
-// Sample data - would come from API in production
-const baseFeeData = [
-  { time: '00:00', baseFee: 10.2 },
-  { time: '02:00', baseFee: 11.5 },
-  { time: '04:00', baseFee: 12.8 },
-  { time: '06:00', baseFee: 14.2 },
-  { time: '08:00', baseFee: 13.7 },
-  { time: '10:00', baseFee: 12.4 },
-  { time: '12:00', baseFee: 11.9 },
-  { time: '14:00', baseFee: 11.6 },
-  { time: '16:00', baseFee: 12.5 },
-  { time: '18:00', baseFee: 13.8 },
-  { time: '20:00', baseFee: 15.2 },
-  { time: '22:00', baseFee: 12.1 },
-];
-
-const costComparisonData = [
-  { time: '00:00', blobCost: 0.0012, calldataCost: 0.0042 },
-  { time: '02:00', blobCost: 0.0013, calldataCost: 0.0045 },
-  { time: '04:00', blobCost: 0.0015, calldataCost: 0.0048 },
-  { time: '06:00', blobCost: 0.0018, calldataCost: 0.0052 },
-  { time: '08:00', blobCost: 0.0017, calldataCost: 0.0049 },
-  { time: '10:00', blobCost: 0.0016, calldataCost: 0.0047 },
-  { time: '12:00', blobCost: 0.0014, calldataCost: 0.0044 },
-  { time: '14:00', blobCost: 0.0013, calldataCost: 0.0043 },
-  { time: '16:00', blobCost: 0.0015, calldataCost: 0.0046 },
-  { time: '18:00', blobCost: 0.0017, calldataCost: 0.0051 },
-  { time: '20:00', blobCost: 0.0019, calldataCost: 0.0056 },
-  { time: '22:00', blobCost: 0.0014, calldataCost: 0.0045 },
-];
+import { useApiData } from '@/hooks/useApiData';
+import { getChartData, ChartData } from '@/lib/api/charts';
+import { useNetwork } from '@/hooks/useNetwork';
 
 export default function BlobGraphs() {
+  const { selectedNetwork } = useNetwork();
+  const fetchCharts = useCallback(() => getChartData(selectedNetwork.apiParam), [selectedNetwork]);
+  const { data, isLoading, error } = useApiData<ChartData>(fetchCharts, [selectedNetwork]);
+
+  const baseFeeData = data?.baseFeeData ?? [];
+  const costData = data?.costData ?? [];
+
   return (
     <section className="mb-10">
       <h2 className="text-xl font-windsor-bold text-titleText mb-4">Data Trends</h2>
@@ -51,82 +30,95 @@ export default function BlobGraphs() {
         <div className="bg-container p-4 rounded-lg shadow-md">
           <h3 className="text-md font-medium mb-4 text-titleText">Blob Base Fee over Time (gwei)</h3>
           <div className="h-72">
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart
-                data={baseFeeData}
-                margin={{ top: 5, right: 30, left: 30, bottom: 50 }}
-              >
-                <CartesianGrid strokeDasharray="3 3" stroke="#333" />
-                <XAxis 
-                  dataKey="time" 
-                  stroke="#888" 
-                  tick={{ fontSize: 12 }}
-                  label={{ value: 'Time (UTC)', position: 'insideBottom', offset: -5, fill: '#888', fontSize: 12 }}
-                />
-                <YAxis 
-                  stroke="#888" 
-                  tick={{ fontSize: 12 }}
-                  label={{ value: 'gwei', angle: -90, position: 'insideLeft', offset: -15, fill: '#888', fontSize: 12 }}
-                />
-                <Tooltip 
-                  contentStyle={{ backgroundColor: '#111', borderColor: '#333' }}
-                  labelStyle={{ color: '#ddd' }}
-                />
-                <Legend wrapperStyle={{ paddingTop: '40px', marginBottom: '20px' }} verticalAlign="bottom" />
-                <Line 
-                  type="monotone" 
-                  dataKey="baseFee" 
-                  stroke="#3498db" 
-                  strokeWidth={2}
-                  activeDot={{ r: 8 }}
-                  name="Base Fee (gwei)"
-                />
-              </LineChart>
-            </ResponsiveContainer>
+            {isLoading ? (
+              <div className="flex items-center justify-center h-full text-[#6e7687] text-sm">Loading chart data...</div>
+            ) : error ? (
+              <div className="flex items-center justify-center h-full text-red-400 text-sm">Failed to load chart data</div>
+            ) : baseFeeData.length === 0 ? (
+              <div className="flex items-center justify-center h-full text-[#6e7687] text-sm">No data available</div>
+            ) : (
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart
+                  data={baseFeeData}
+                  margin={{ top: 5, right: 30, left: 30, bottom: 50 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" stroke="#333" />
+                  <XAxis
+                    dataKey="time"
+                    stroke="#888"
+                    tick={{ fontSize: 12 }}
+                    label={{ value: 'Time (UTC)', position: 'insideBottom', offset: -5, fill: '#888', fontSize: 12 }}
+                    interval="preserveStartEnd"
+                  />
+                  <YAxis
+                    stroke="#888"
+                    tick={{ fontSize: 12 }}
+                    label={{ value: 'gwei', angle: -90, position: 'insideLeft', offset: -15, fill: '#888', fontSize: 12 }}
+                  />
+                  <Tooltip
+                    contentStyle={{ backgroundColor: '#111', borderColor: '#333' }}
+                    labelStyle={{ color: '#ddd' }}
+                  />
+                  <Legend wrapperStyle={{ paddingTop: '40px', marginBottom: '20px' }} verticalAlign="bottom" />
+                  <Line
+                    type="monotone"
+                    dataKey="baseFee"
+                    stroke="#3498db"
+                    strokeWidth={2}
+                    activeDot={{ r: 8 }}
+                    dot={false}
+                    name="Base Fee (gwei)"
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            )}
           </div>
         </div>
-        
+
         <div className="bg-container p-4 rounded-lg shadow-md">
-          <h3 className="text-md font-medium mb-4 text-titleText">Blob Cost vs Calldata Cost (ETH)</h3>
+          <h3 className="text-md font-medium mb-4 text-titleText">Blob Cost per Block (ETH)</h3>
           <div className="h-72">
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart
-                data={costComparisonData}
-                margin={{ top: 5, right: 30, left: 30, bottom: 50 }}
-              >
-                <CartesianGrid strokeDasharray="3 3" stroke="#333" />
-                <XAxis 
-                  dataKey="time" 
-                  stroke="#888" 
-                  tick={{ fontSize: 12 }}
-                  label={{ value: 'Time (UTC)', position: 'insideBottom', offset: -5, fill: '#888', fontSize: 12 }}
-                />
-                <YAxis 
-                  stroke="#888" 
-                  tick={{ fontSize: 12 }}
-                  label={{ value: 'ETH', angle: -90, position: 'insideLeft', offset: -15, fill: '#888', fontSize: 12 }}
-                />
-                <Tooltip 
-                  contentStyle={{ backgroundColor: '#111', borderColor: '#333' }}
-                  labelStyle={{ color: '#ddd' }}
-                />
-                <Legend wrapperStyle={{ paddingTop: '40px', marginBottom: '20px' }} verticalAlign="bottom" />
-                <Line 
-                  type="monotone" 
-                  dataKey="blobCost" 
-                  stroke="#2ecc71" 
-                  strokeWidth={2}
-                  name="Blob Cost (ETH)"
-                />
-                <Line 
-                  type="monotone" 
-                  dataKey="calldataCost" 
-                  stroke="#e74c3c" 
-                  strokeWidth={2}
-                  name="Calldata Cost (ETH)"
-                />
-              </LineChart>
-            </ResponsiveContainer>
+            {isLoading ? (
+              <div className="flex items-center justify-center h-full text-[#6e7687] text-sm">Loading chart data...</div>
+            ) : error ? (
+              <div className="flex items-center justify-center h-full text-red-400 text-sm">Failed to load chart data</div>
+            ) : costData.length === 0 ? (
+              <div className="flex items-center justify-center h-full text-[#6e7687] text-sm">No data available</div>
+            ) : (
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart
+                  data={costData}
+                  margin={{ top: 5, right: 30, left: 30, bottom: 50 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" stroke="#333" />
+                  <XAxis
+                    dataKey="time"
+                    stroke="#888"
+                    tick={{ fontSize: 12 }}
+                    label={{ value: 'Time (UTC)', position: 'insideBottom', offset: -5, fill: '#888', fontSize: 12 }}
+                    interval="preserveStartEnd"
+                  />
+                  <YAxis
+                    stroke="#888"
+                    tick={{ fontSize: 12 }}
+                    label={{ value: 'ETH', angle: -90, position: 'insideLeft', offset: -15, fill: '#888', fontSize: 12 }}
+                  />
+                  <Tooltip
+                    contentStyle={{ backgroundColor: '#111', borderColor: '#333' }}
+                    labelStyle={{ color: '#ddd' }}
+                  />
+                  <Legend wrapperStyle={{ paddingTop: '40px', marginBottom: '20px' }} verticalAlign="bottom" />
+                  <Line
+                    type="monotone"
+                    dataKey="blobCost"
+                    stroke="#2ecc71"
+                    strokeWidth={2}
+                    dot={false}
+                    name="Avg Blob Cost (ETH)"
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/MetricsCharts.tsx
+++ b/src/components/MetricsCharts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
   LineChart,
   Line,
@@ -10,158 +10,150 @@ import {
   Tooltip,
   ResponsiveContainer
 } from 'recharts';
-
-// Sample data - would come from API in production
-const baseFeeData = [
-  { time: '00:00', baseFee: 10.2 },
-  { time: '02:00', baseFee: 11.5 },
-  { time: '04:00', baseFee: 12.8 },
-  { time: '06:00', baseFee: 14.2 },
-  { time: '08:00', baseFee: 13.7 },
-  { time: '10:00', baseFee: 12.4 },
-  { time: '12:00', baseFee: 11.9 },
-  { time: '14:00', baseFee: 11.6 },
-  { time: '16:00', baseFee: 12.5 },
-  { time: '18:00', baseFee: 13.8 },
-  { time: '20:00', baseFee: 15.2 },
-  { time: '22:00', baseFee: 12.1 },
-];
-
-const costComparisonData = [
-  { time: '00:00', blobCost: 0.0012, calldataCost: 0.0042 },
-  { time: '02:00', blobCost: 0.0013, calldataCost: 0.0045 },
-  { time: '04:00', blobCost: 0.0015, calldataCost: 0.0048 },
-  { time: '06:00', blobCost: 0.0018, calldataCost: 0.0052 },
-  { time: '08:00', blobCost: 0.0017, calldataCost: 0.0049 },
-  { time: '10:00', blobCost: 0.0016, calldataCost: 0.0047 },
-  { time: '12:00', blobCost: 0.0014, calldataCost: 0.0044 },
-  { time: '14:00', blobCost: 0.0013, calldataCost: 0.0043 },
-  { time: '16:00', blobCost: 0.0015, calldataCost: 0.0046 },
-  { time: '18:00', blobCost: 0.0017, calldataCost: 0.0051 },
-  { time: '20:00', blobCost: 0.0019, calldataCost: 0.0056 },
-  { time: '22:00', blobCost: 0.0014, calldataCost: 0.0045 },
-];
+import { useApiData } from '@/hooks/useApiData';
+import { getChartData, ChartData } from '@/lib/api/charts';
+import { useNetwork } from '@/hooks/useNetwork';
 
 export default function MetricsCharts() {
+  const { selectedNetwork } = useNetwork();
+  const fetchCharts = useCallback(() => getChartData(selectedNetwork.apiParam), [selectedNetwork]);
+  const { data, isLoading, error } = useApiData<ChartData>(fetchCharts, [selectedNetwork]);
+
+  const baseFeeData = data?.baseFeeData ?? [];
+  const costData = data?.costData ?? [];
+
   return (
     <section>
       <h2 className="text-2xl font-windsor-bold text-white mb-3">Data Trends</h2>
       <div className="flex flex-col space-y-6">
         <div className="rounded-tl-lg mb-2 border border-divider rounded-tr-lg rounded-bl-lg bg-blue/10 p-3 relative after:content-[''] after:absolute after:border-b-[10px] after:border-r-[10px] after:border-[#171c28] after:right-0 after:bottom-0 after:w-full after:h-full after:pointer-events-none after:rounded-br-lg after:rounded-bl-lg after:rounded-tr-lg after:-right-0 after:-bottom-0 after:left-[11px] after:top-[11px]">
-          <h3 className="text-md font-medium mb-4 text-white">Base Fee over Time (gwei)</h3>
+          <h3 className="text-md font-medium mb-4 text-white">Blob Base Fee over Time (gwei)</h3>
           <div className="h-56 relative">
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart
-                data={baseFeeData}
-                margin={{ top: 5, right: 30, left: 30, bottom: 35 }}
-              >
-                <CartesianGrid strokeDasharray="3 3" stroke="#333" opacity={0} />
-                <XAxis 
-                  dataKey="time" 
-                  stroke="#6e7687" 
-                  tick={{ fill: '#6e7687', fontSize: 12 }}
-                  axisLine={{ stroke: '#333' }}
-                  tickLine={{ stroke: '#333' }}
-                  label={{ value: 'Time (UTC)', position: 'insideBottom', offset: -5, fill: '#6e7687', fontSize: 12 }}
-                />
-                <YAxis 
-                  stroke="#6e7687" 
-                  tick={{ fill: '#6e7687', fontSize: 12 }}
-                  axisLine={{ stroke: '#333' }}
-                  tickLine={{ stroke: '#333' }}
-                  label={{ value: 'gwei', angle: -90, position: 'insideLeft', offset: -15, fill: '#6e7687', fontSize: 12 }}
-                />
-                <Tooltip 
-                  contentStyle={{ 
-                    backgroundColor: '#14161a', 
-                    borderColor: '#333', 
-                    fontSize: '12px',
-                    borderRadius: '8px',
-                    padding: '8px' 
-                  }}
-                  labelStyle={{ color: '#fff', fontSize: '12px' }}
-                  itemStyle={{ color: '#fff', fontSize: '12px' }}
-                />
-                <Line 
-                  type="monotone" 
-                  dataKey="baseFee" 
-                  stroke="rgb(59, 130, 246)" 
-                  strokeWidth={2}
-                  activeDot={{ r: 8 }}
-                  name="Base Fee (gwei)"
-                />
-              </LineChart>
-            </ResponsiveContainer>
-            <div className="absolute bottom-0 left-0 right-0 text-center text-xs text-[#6e7687]">
-              <span className="inline-flex items-center mr-4">
-                <span className="inline-block w-3 h-3 bg-blue mr-1 rounded-sm" style={{ backgroundColor: 'rgb(59, 130, 246)' }}></span>
-                Base Fee (gwei)
-              </span>
-            </div>
+            {isLoading ? (
+              <div className="flex items-center justify-center h-full text-[#6e7687] text-sm">Loading chart data...</div>
+            ) : error ? (
+              <div className="flex items-center justify-center h-full text-red-400 text-sm">Failed to load chart data</div>
+            ) : baseFeeData.length === 0 ? (
+              <div className="flex items-center justify-center h-full text-[#6e7687] text-sm">No data available</div>
+            ) : (
+              <>
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart
+                    data={baseFeeData}
+                    margin={{ top: 5, right: 30, left: 30, bottom: 35 }}
+                  >
+                    <CartesianGrid strokeDasharray="3 3" stroke="#333" opacity={0} />
+                    <XAxis
+                      dataKey="time"
+                      stroke="#6e7687"
+                      tick={{ fill: '#6e7687', fontSize: 12 }}
+                      axisLine={{ stroke: '#333' }}
+                      tickLine={{ stroke: '#333' }}
+                      label={{ value: 'Time (UTC)', position: 'insideBottom', offset: -5, fill: '#6e7687', fontSize: 12 }}
+                      interval="preserveStartEnd"
+                    />
+                    <YAxis
+                      stroke="#6e7687"
+                      tick={{ fill: '#6e7687', fontSize: 12 }}
+                      axisLine={{ stroke: '#333' }}
+                      tickLine={{ stroke: '#333' }}
+                      label={{ value: 'gwei', angle: -90, position: 'insideLeft', offset: -15, fill: '#6e7687', fontSize: 12 }}
+                    />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: '#14161a',
+                        borderColor: '#333',
+                        fontSize: '12px',
+                        borderRadius: '8px',
+                        padding: '8px'
+                      }}
+                      labelStyle={{ color: '#fff', fontSize: '12px' }}
+                      itemStyle={{ color: '#fff', fontSize: '12px' }}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="baseFee"
+                      stroke="rgb(59, 130, 246)"
+                      strokeWidth={2}
+                      activeDot={{ r: 8 }}
+                      dot={false}
+                      name="Base Fee (gwei)"
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+                <div className="absolute bottom-0 left-0 right-0 text-center text-xs text-[#6e7687]">
+                  <span className="inline-flex items-center mr-4">
+                    <span className="inline-block w-3 h-3 bg-blue mr-1 rounded-sm" style={{ backgroundColor: 'rgb(59, 130, 246)' }}></span>
+                    Base Fee (gwei)
+                  </span>
+                </div>
+              </>
+            )}
           </div>
         </div>
-        
+
         <div className="rounded-tl-lg border border-divider rounded-tr-lg rounded-bl-lg bg-blue/10 p-3 relative after:content-[''] after:absolute after:border-b-[10px] after:border-r-[10px] after:border-[#171c28] after:right-0 after:bottom-0 after:w-full after:h-full after:pointer-events-none after:rounded-br-lg after:rounded-bl-lg after:rounded-tr-lg after:-right-0 after:-bottom-0 after:left-[11px] after:top-[11px]">
-          <h3 className="text-md font-medium mb-4 text-white">Cost Comparison: Blob vs Calldata (ETH)</h3>
+          <h3 className="text-md font-medium mb-4 text-white">Blob Cost per Block (ETH)</h3>
           <div className="h-56 relative">
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart
-                data={costComparisonData}
-                margin={{ top: 5, right: 30, left: 30, bottom: 35 }}
-              >
-                <CartesianGrid strokeDasharray="3 3" stroke="#333" opacity={0} />
-                <XAxis 
-                  dataKey="time" 
-                  stroke="#6e7687" 
-                  tick={{ fill: '#6e7687', fontSize: 12 }}
-                  axisLine={{ stroke: '#333' }}
-                  tickLine={{ stroke: '#333' }}
-                  label={{ value: 'Time (UTC)', position: 'insideBottom', offset: -5, fill: '#6e7687', fontSize: 12 }}
-                />
-                <YAxis 
-                  stroke="#6e7687" 
-                  tick={{ fill: '#6e7687', fontSize: 12 }}
-                  axisLine={{ stroke: '#333' }}
-                  tickLine={{ stroke: '#333' }}
-                  label={{ value: 'ETH', angle: -90, position: 'insideLeft', offset: -15, fill: '#6e7687', fontSize: 12 }}
-                />
-                <Tooltip 
-                  contentStyle={{ 
-                    backgroundColor: '#14161a', 
-                    borderColor: '#333', 
-                    fontSize: '12px',
-                    borderRadius: '8px',
-                    padding: '8px' 
-                  }}
-                  labelStyle={{ color: '#fff', fontSize: '12px' }}
-                  itemStyle={{ color: '#fff', fontSize: '12px' }}
-                />
-                <Line 
-                  type="monotone" 
-                  dataKey="blobCost" 
-                  stroke="rgb(59, 130, 246)" 
-                  strokeWidth={2}
-                  name="Blob Cost (ETH)"
-                />
-                <Line 
-                  type="monotone" 
-                  dataKey="calldataCost" 
-                  stroke="#6A5ACD" 
-                  strokeWidth={2}
-                  name="Calldata Cost (ETH)"
-                />
-              </LineChart>
-            </ResponsiveContainer>
-            <div className="absolute bottom-0 left-0 right-0 text-center text-xs text-[#6e7687]">
-              <span className="inline-flex items-center mr-4">
-                <span className="inline-block w-3 h-3 mr-1 rounded-sm" style={{ backgroundColor: 'rgb(59, 130, 246)' }}></span>
-                Blob Cost (ETH)
-              </span>
-              <span className="inline-flex items-center">
-                <span className="inline-block w-3 h-3 bg-purple mr-1 rounded-sm"></span>
-                Calldata Cost (ETH)
-              </span>
-            </div>
+            {isLoading ? (
+              <div className="flex items-center justify-center h-full text-[#6e7687] text-sm">Loading chart data...</div>
+            ) : error ? (
+              <div className="flex items-center justify-center h-full text-red-400 text-sm">Failed to load chart data</div>
+            ) : costData.length === 0 ? (
+              <div className="flex items-center justify-center h-full text-[#6e7687] text-sm">No data available</div>
+            ) : (
+              <>
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart
+                    data={costData}
+                    margin={{ top: 5, right: 30, left: 30, bottom: 35 }}
+                  >
+                    <CartesianGrid strokeDasharray="3 3" stroke="#333" opacity={0} />
+                    <XAxis
+                      dataKey="time"
+                      stroke="#6e7687"
+                      tick={{ fill: '#6e7687', fontSize: 12 }}
+                      axisLine={{ stroke: '#333' }}
+                      tickLine={{ stroke: '#333' }}
+                      label={{ value: 'Time (UTC)', position: 'insideBottom', offset: -5, fill: '#6e7687', fontSize: 12 }}
+                      interval="preserveStartEnd"
+                    />
+                    <YAxis
+                      stroke="#6e7687"
+                      tick={{ fill: '#6e7687', fontSize: 12 }}
+                      axisLine={{ stroke: '#333' }}
+                      tickLine={{ stroke: '#333' }}
+                      label={{ value: 'ETH', angle: -90, position: 'insideLeft', offset: -15, fill: '#6e7687', fontSize: 12 }}
+                    />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: '#14161a',
+                        borderColor: '#333',
+                        fontSize: '12px',
+                        borderRadius: '8px',
+                        padding: '8px'
+                      }}
+                      labelStyle={{ color: '#fff', fontSize: '12px' }}
+                      itemStyle={{ color: '#fff', fontSize: '12px' }}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="blobCost"
+                      stroke="rgb(59, 130, 246)"
+                      strokeWidth={2}
+                      dot={false}
+                      name="Avg Blob Cost (ETH)"
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+                <div className="absolute bottom-0 left-0 right-0 text-center text-xs text-[#6e7687]">
+                  <span className="inline-flex items-center mr-4">
+                    <span className="inline-block w-3 h-3 mr-1 rounded-sm" style={{ backgroundColor: 'rgb(59, 130, 246)' }}></span>
+                    Avg Blob Cost (ETH)
+                  </span>
+                </div>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/src/lib/api/charts.ts
+++ b/src/lib/api/charts.ts
@@ -1,0 +1,102 @@
+import { ApiResponse, BlobResponse } from '../../types';
+import { fetchApi } from './core';
+
+export interface ChartDataPoint {
+    time: string;
+    baseFee: number;
+}
+
+export interface CostDataPoint {
+    time: string;
+    blobCost: number;
+}
+
+export interface ChartData {
+    baseFeeData: ChartDataPoint[];
+    costData: CostDataPoint[];
+}
+
+/**
+ * Fetches recent blobs and transforms them into time-series chart data.
+ * Groups blobs by block and computes per-block averages.
+ */
+export async function getChartData(network?: string): Promise<ChartData> {
+    const response = await fetchApi<ApiResponse<BlobResponse[]>>(
+        `/blob/latest?limit=200`,
+        network
+    );
+
+    const blobs = response.data;
+    if (!blobs || blobs.length === 0) {
+        return { baseFeeData: [], costData: [] };
+    }
+
+    // Group blobs by block number to get per-block aggregates
+    const blockMap = new Map<number, {
+        timestamp: string;
+        baseFees: bigint[];
+        costs: number[];
+    }>();
+
+    for (const blob of blobs) {
+        const block = blob.block_number;
+        if (!blockMap.has(block)) {
+            blockMap.set(block, {
+                timestamp: blob.timestamp,
+                baseFees: [],
+                costs: [],
+            });
+        }
+        const entry = blockMap.get(block)!;
+
+        if (blob.base_fee_per_blob_gas) {
+            try {
+                entry.baseFees.push(BigInt(blob.base_fee_per_blob_gas));
+            } catch {
+                // skip invalid values
+            }
+        }
+
+        if (blob.total_cost_eth) {
+            const cost = parseFloat(blob.total_cost_eth);
+            if (!isNaN(cost)) {
+                entry.costs.push(cost);
+            }
+        }
+    }
+
+    // Sort blocks chronologically (ascending)
+    const sortedBlocks = Array.from(blockMap.entries())
+        .sort(([a], [b]) => a - b);
+
+    const baseFeeData: ChartDataPoint[] = [];
+    const costData: CostDataPoint[] = [];
+
+    for (const [, { timestamp, baseFees, costs }] of sortedBlocks) {
+        const time = formatChartTime(timestamp);
+
+        if (baseFees.length > 0) {
+            const avgWei = baseFees.reduce((a, b) => a + b, BigInt(0)) / BigInt(baseFees.length);
+            // Convert wei to gwei (1 gwei = 10^9 wei)
+            const gwei = Number(avgWei) / 1e9;
+            baseFeeData.push({ time, baseFee: parseFloat(gwei.toFixed(4)) });
+        }
+
+        if (costs.length > 0) {
+            const avgCost = costs.reduce((a, b) => a + b, 0) / costs.length;
+            costData.push({ time, blobCost: parseFloat(avgCost.toFixed(6)) });
+        }
+    }
+
+    return { baseFeeData, costData };
+}
+
+function formatChartTime(timestamp: string): string {
+    const date = new Date(timestamp);
+    return date.toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+        timeZone: 'UTC',
+    });
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded mock data in MetricsCharts and BlobGraphs with live API data from `/blob/latest`
- New `src/lib/api/charts.ts` fetches 200 recent blobs, groups by block, and computes per-block avg base fee (gwei) and avg blob cost (ETH)
- Charts now show loading, error, and empty states

## Test plan
- [ ] Verify charts load real data when API is available
- [ ] Verify loading state displays while fetching
- [ ] Verify error state displays when API is down
- [ ] Verify network switching updates chart data