### PR TITLE
Add comprehensive CI, lint, typecheck, and build jobs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "next/core-web-vitals",
+    "next/typescript"
+  ]
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 10
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:15"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,55 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type checks
+        run: npm run typecheck
+
   test:
-    name: Test
+    name: Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,3 +85,21 @@ jobs:
           name: coverage-report
           path: coverage
           retention-days: 7
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build app
+        run: npm run build

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,32 @@
+name: PR Title (Conventional Commits)
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: "PR title must not be empty after the type prefix."

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,0 +1,32 @@
+name: Secrets Scan
+
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+  schedule:
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
-.PHONY: test test-coverage
+.PHONY: lint typecheck test test-coverage build ci
 
 NPM = npm
 COVERAGE_THRESHOLD ?= 90
+
+lint:
+	$(NPM) run lint
+
+typecheck:
+	$(NPM) run typecheck
 
 test:
 	$(NPM) run test
@@ -15,3 +21,8 @@ test-coverage:
 		exit 1; \
 	fi; \
 	echo "OK: Coverage $${COVERAGE}% meets $(COVERAGE_THRESHOLD)% threshold"
+
+build:
+	$(NPM) run build
+
+ci: lint typecheck test-coverage build

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ This project uses Vitest with a CI-enforced 90% line coverage minimum for core l
 - `npm run test-coverage` - run tests with coverage report
 - `make test-coverage` - run coverage and enforce the threshold locally
 
+## CI/CD
+
+GitHub Actions workflows are configured for:
+
+- `CI` (`.github/workflows/ci.yml`): lint, typecheck, test coverage enforcement, and production build checks on PRs and pushes to `main`/`master`
+- `PR Title` (`.github/workflows/pr-title.yml`): enforces conventional commit style PR titles
+- `Secrets Scan` (`.github/workflows/secrets-scan.yml`): gitleaks checks on PR/push, weekly schedule, and manual dispatch
+
 ## Project Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "test": "vitest run",
     "test-watch": "vitest",
     "test-coverage": "vitest run --coverage"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import type { Metadata } from 'next';
+import Script from 'next/script';
 
 // Removed Inter font
 
@@ -19,7 +20,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <script src="https://kit.fontawesome.com/7f8f63cf7a.js" crossOrigin="anonymous"></script>
+        <Script
+          src="https://kit.fontawesome.com/7f8f63cf7a.js"
+          crossOrigin="anonymous"
+          strategy="afterInteractive"
+        />
       </head>
       <body>
         {children}

--- a/src/app/user/[address]/page.tsx
+++ b/src/app/user/[address]/page.tsx
@@ -42,7 +42,7 @@ function BlobTable({ blobs, showBlock }: { blobs: BlobResponse[]; showBlock: boo
           </tr>
         </thead>
         <tbody className="divide-y divide-divider">
-          {blobs.map((blob, index) => (
+          {blobs.map((blob) => (
             <tr key={`${blob.tx_hash}-${blob.blob_index}`} className="bg-gradient-to-r from-[#161a29] to-[#19191e]/60 hover:bg-gradient-to-r hover:from-[#202538]/70 hover:to-[#242731]/70 transition-colors">
               <td className="py-3 px-6 text-sm font-mono text-white">{truncateTxHash(blob.tx_hash)}</td>
               {showBlock && (

--- a/src/components/ExplainerSection.tsx
+++ b/src/components/ExplainerSection.tsx
@@ -8,7 +8,7 @@ export default function ExplainerSection() {
       
       <div className="prose prose-invert max-w-none">
         <p className="text-[#b8bdc7]">
-        Blobs (Binary Large Objects) are data structures introduced in Ethereum's EIP-4844 ("Proto-Danksharding") that provide cost-efficient storage for Layer 2 rollups, reducing fees compared to traditional calldata. These temporary structures attach to blocks without affecting Ethereum's state.
+        Blobs (Binary Large Objects) are data structures introduced in Ethereum&apos;s EIP-4844 (&quot;Proto-Danksharding&quot;) that provide cost-efficient storage for Layer 2 rollups, reducing fees compared to traditional calldata. These temporary structures attach to blocks without affecting Ethereum&apos;s state.
         </p>
         
         <p className="text-[#b8bdc7] mt-4">
@@ -18,7 +18,7 @@ export default function ExplainerSection() {
         <ul className="list-disc pl-5 mt-2 text-[#b8bdc7]">
           <li>Lower transaction costs for rollup users</li>
           <li>Increased data throughput for Layer 2 solutions</li>
-          <li>Progress toward Ethereum's full sharding</li>
+          <li>Progress toward Ethereum&apos;s full sharding</li>
           <li>Data availability without permanent state bloat</li>
         </ul>
         

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import SearchModal from './SearchModal';
 import useSearchShortcut from '../hooks/useSearchShortcut';
 import useScrollLock from '../hooks/useScrollLock';
-import useDragToClose from '../hooks/useDragToClose';
 import { useNetwork } from '../hooks/useNetwork';
-import { NETWORKS, DEFAULT_NETWORK } from '../constants';
+import { DEFAULT_NETWORK } from '../constants';
 
 type TimeRange = '24h' | '7d' | '30d' | 'All';
 
@@ -16,11 +15,10 @@ export default function Header() {
   const { selectedNetwork, setSelectedNetwork, networkOptions } = useNetwork();
   const [isMounted, setIsMounted] = useState(false);
   const [isNetworkDropdownOpen, setIsNetworkDropdownOpen] = useState(false);
-  const [isConnected, setIsConnected] = useState(true);
+  const isConnected = true;
   const [selectedTimeRange, setSelectedTimeRange] = useState<TimeRange>('24h');
   const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  const mobileMenuRef = useRef<HTMLDivElement>(null);
 
   // Lock scrolling when the mobile menu is open
   useScrollLock(isMobileMenuOpen);
@@ -47,16 +45,6 @@ export default function Header() {
       setIsMobileMenuOpen(false);
     }
   }, [isMobileMenuOpen]);
-
-  const toggleMobileMenu = () => {
-    // Force toggle the mobile menu state
-    setIsMobileMenuOpen(prev => !prev);
-
-    // Close the network dropdown if it's open
-    if (isNetworkDropdownOpen) {
-      setIsNetworkDropdownOpen(false);
-    }
-  };
 
   // Close mobile menu when clicking outside
   // Remove the existing click outside handler as it may be interfering

--- a/src/components/TopUsersTable.tsx
+++ b/src/components/TopUsersTable.tsx
@@ -22,7 +22,7 @@ export default function TopUsersTable() {
     const setupTooltips = () => {
       const tooltipElements = document.querySelectorAll('[data-tooltip]');
 
-      const handleMouseEnter = (e: MouseEvent) => {
+      const handleMouseEnter = (e: Event) => {
         const target = e.currentTarget as HTMLElement;
         const tooltipText = target.getAttribute('data-tooltip');
 
@@ -96,14 +96,14 @@ export default function TopUsersTable() {
 
       // Add event listeners
       tooltipElements.forEach(el => {
-        el.addEventListener('mouseenter', handleMouseEnter as any);
+        el.addEventListener('mouseenter', handleMouseEnter);
         el.addEventListener('mouseleave', handleMouseLeave);
       });
 
       return () => {
         // Cleanup
         tooltipElements.forEach(el => {
-          el.removeEventListener('mouseenter', handleMouseEnter as any);
+          el.removeEventListener('mouseenter', handleMouseEnter);
           el.removeEventListener('mouseleave', handleMouseLeave);
         });
 

--- a/src/hooks/useApiData.ts
+++ b/src/hooks/useApiData.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, type DependencyList } from 'react';
 
 /**
  * Generic hook for fetching data from API with loading and error states
@@ -11,7 +11,7 @@ import { useEffect, useState, useCallback } from 'react';
  */
 export function useApiData<T>(
   fetchFunction: () => Promise<T>,
-  dependencies: any[] = [],
+  dependencies: DependencyList = [],
   initialData?: T
 ) {
   const [data, setData] = useState<T | undefined>(initialData);
@@ -52,7 +52,7 @@ export function useApiData<T>(
  */
 export function usePaginatedApiData<T>(
   fetchFunction: (page: number, limit: number, network?: string) => Promise<T>,
-  dependencies: any[] = [],
+  dependencies: DependencyList = [],
   network?: string
 ) {
   const [page, setPage] = useState<number>(1);

--- a/src/hooks/useDragToClose.ts
+++ b/src/hooks/useDragToClose.ts
@@ -53,7 +53,7 @@ export default function useDragToClose({
       }
     };
     
-    const handleTouchEnd = (e: TouchEvent) => {
+    const handleTouchEnd = () => {
       if (startYRef.current === null || currentYRef.current === null) return;
       
       const elementHeight = modalElement.offsetHeight;

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 /**
  * Custom hook for managing local storage state

--- a/src/lib/api/index.test.ts
+++ b/src/lib/api/index.test.ts
@@ -1,8 +1,8 @@
 describe('api/index', () => {
   it('exports complete api surface', async () => {
-    const module = await import('./index');
-    const api = module.default;
-    const namedApi = module.api;
+    const apiModule = await import('./index');
+    const api = apiModule.default;
+    const namedApi = apiModule.api;
 
     expect(api).toBe(namedApi);
     expect(api).toHaveProperty('getLatestBlocks');

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "src/test/**/*"
+  ]
+}


### PR DESCRIPTION
## Summary
- expand GitHub Actions CI to lint, typecheck, tests, and build with concurrency, caching, and coverage artifact retention
- add lint/typecheck scripts, Makefile targets, and tsconfig/typecheck plus ESLint/Dependabot/PR title/secrets workflows for infra parity with referenced repo
- polish client code (hooks, components, layout) for stricter linting and consistency

## Testing
- Not run (not requested)