### PR TITLE
chore: add dependabot config with conventional commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with `chore` prefix and `scope` inclusion so PR titles follow the repo's conventional commit format (e.g., `chore(deps): bump ...`)
- Covers both npm packages and GitHub Actions on a weekly schedule

## Test plan
- [ ] Verify Dependabot opens PRs with `chore(deps):` / `chore(deps-dev):` prefixed titles