### PR TITLE
chore: remove dependabot dependency grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,6 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    groups:
-      production-dependencies:
-        dependency-type: "production"
-      development-dependencies:
-        dependency-type: "development"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
- Removes all dependency grouping from Dependabot config so each dependency gets its own PR

## Test plan
- [ ] Verify Dependabot opens individual PRs per dependency instead of grouped batches