### PR TITLE
feat: add websocket live data layer

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import type { Metadata } from 'next';
 import Script from 'next/script';
+import AppProviders from '@/components/AppProviders';
 
 // Removed Inter font
 
@@ -27,7 +28,7 @@ export default function RootLayout({
         />
       </head>
       <body>
-        {children}
+        <AppProviders>{children}</AppProviders>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,11 +9,9 @@ import TopUsersTable from '@/components/TopUsersTable';
 import MempoolTable from '@/components/MempoolTable';
 import ExplainerSection from '@/components/ExplainerSection';
 import Footer from '@/components/Footer';
-import { TimeRangeProvider } from '@/contexts/TimeRangeContext';
 
 export default function Home() {
   return (
-    <TimeRangeProvider>
     <main className="min-h-screen bg-background bg-grid-pattern bg-grid-size">
       <Header />
       <div className="container mx-auto px-4 py-8 max-w-7xl">
@@ -50,6 +48,5 @@ export default function Home() {
       </div>
       <Footer />
     </main>
-    </TimeRangeProvider>
   );
 }

--- a/src/components/AppProviders.tsx
+++ b/src/components/AppProviders.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import React, { ReactNode } from 'react';
+import { LiveDataProvider } from '@/contexts/LiveDataContext';
+import { TimeRangeProvider } from '@/contexts/TimeRangeContext';
+import { useNetwork } from '@/hooks/useNetwork';
+
+export default function AppProviders({ children }: { children: ReactNode }) {
+  const { selectedNetwork } = useNetwork();
+
+  return (
+    <TimeRangeProvider>
+      <LiveDataProvider key={selectedNetwork.apiParam} network={selectedNetwork.apiParam}>
+        {children}
+      </LiveDataProvider>
+    </TimeRangeProvider>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,13 +9,25 @@ import useScrollLock from '../hooks/useScrollLock';
 import { useNetwork } from '../hooks/useNetwork';
 import { DEFAULT_NETWORK } from '../constants';
 import { useTimeRange, type TimeRange } from '../contexts/TimeRangeContext';
+import { useBlobWebSocket } from '../contexts/LiveDataContext';
+import { BlobWebSocketConnectionState } from '../types';
+
+const LIVE_STATUS_STYLES: Record<BlobWebSocketConnectionState, { label: string; color: string }> = {
+  connecting: { label: 'Connecting', color: 'bg-yellow-400' },
+  connected: { label: 'Connected', color: 'bg-green' },
+  stale: { label: 'Stale', color: 'bg-yellow-400' },
+  reconnecting: { label: 'Reconnecting', color: 'bg-yellow-400' },
+  disconnected: { label: 'Disconnected', color: 'bg-red' },
+};
 
 export default function Header() {
   const { selectedNetwork, setSelectedNetwork, networkOptions } = useNetwork();
   const { timeRange: selectedTimeRange, setTimeRange: setSelectedTimeRange } = useTimeRange();
+  const { connectionState } = useBlobWebSocket();
   const isMounted = useSyncExternalStore(() => () => {}, () => true, () => false);
   const [isNetworkDropdownOpen, setIsNetworkDropdownOpen] = useState(false);
-  const isConnected = true;
+  const liveStatus = LIVE_STATUS_STYLES[connectionState];
+  const shouldAnimateLiveStatus = connectionState !== 'disconnected';
   const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
@@ -147,10 +159,12 @@ export default function Header() {
               {/* Connection Status */}
               <div className="flex items-center space-x-2 mr-4 ml-1">
                 <div className="relative">
-                  <div className={`h-2.5 w-2.5 rounded-full ${isConnected ? 'bg-green' : 'bg-red'}`}></div>
-                  <div className={`absolute inset-0 rounded-full ${isConnected ? 'bg-green' : 'bg-red'} opacity-75 animate-ping`}></div>
+                  <div className={`h-2.5 w-2.5 rounded-full ${liveStatus.color}`}></div>
+                  {shouldAnimateLiveStatus && (
+                    <div className={`absolute inset-0 rounded-full ${liveStatus.color} opacity-75 animate-ping`}></div>
+                  )}
                 </div>
-                <span className="text-sm text-bodyText">{isConnected ? 'Connected' : 'Disconnected'}</span>
+                <span className="text-sm text-bodyText">{liveStatus.label}</span>
               </div>
             </div>
 
@@ -337,10 +351,12 @@ export default function Header() {
                 <i className="fa-regular fa-signal-stream text-blue" aria-hidden="true"></i>
                 <div className="flex items-center space-x-2">
                   <div className="relative">
-                    <div className={`h-2.5 w-2.5 rounded-full ${isConnected ? 'bg-green' : 'bg-red'}`}></div>
-                    <div className={`absolute inset-0 rounded-full ${isConnected ? 'bg-green' : 'bg-red'} opacity-75 animate-ping`}></div>
+                    <div className={`h-2.5 w-2.5 rounded-full ${liveStatus.color}`}></div>
+                    {shouldAnimateLiveStatus && (
+                      <div className={`absolute inset-0 rounded-full ${liveStatus.color} opacity-75 animate-ping`}></div>
+                    )}
                   </div>
-                  <span className="text-base text-bodyText">{isConnected ? 'Connected' : 'Disconnected'}</span>
+                  <span className="text-base text-bodyText">{liveStatus.label}</span>
                 </div>
               </div>
 

--- a/src/components/LatestBlocksTable.tsx
+++ b/src/components/LatestBlocksTable.tsx
@@ -6,13 +6,29 @@ import { api } from '../lib/api';
 import { Block, LatestBlocksResponse } from '../types';
 import DataStateWrapper from './DataStateWrapper';
 import { useNetwork } from '../hooks/useNetwork';
+import { useBlobWebSocket } from '../contexts/LiveDataContext';
+import { transformNewBlockData } from '../lib/api/blocks';
 
 export default function LatestBlocksTable() {
   const { selectedNetwork } = useNetwork();
+  const { latestEvents } = useBlobWebSocket();
 
   const { data, isLoading, error } = useApiData<LatestBlocksResponse>(
     () => api.getLatestBlocks(20, selectedNetwork.apiParam)
   );
+  const displayData = React.useMemo<LatestBlocksResponse | undefined>(() => {
+    if (!latestEvents.new_block) {
+      return data;
+    }
+
+    const liveBlock = transformNewBlockData(latestEvents.new_block.data);
+    return {
+      data: [
+        liveBlock,
+        ...(data?.data || []).filter((block) => block.number !== liveBlock.number),
+      ].slice(0, 20),
+    };
+  }, [data, latestEvents.new_block]);
 
   // Loading state for the table
   const loadingComponent = (
@@ -62,11 +78,11 @@ export default function LatestBlocksTable() {
       <h2 className="text-2xl font-windsor-bold text-white mb-4">Latest Blocks</h2>
 
       <DataStateWrapper
-        isLoading={isLoading}
-        error={error}
+        isLoading={isLoading && !displayData}
+        error={displayData ? null : error}
         loadingComponent={loadingComponent}
       >
-        {data && (
+        {displayData && (
           <div className="overflow-x-auto border border-divider rounded-lg">
             <table className="min-w-full overflow-hidden table-fixed">
               <thead>
@@ -78,7 +94,7 @@ export default function LatestBlocksTable() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-divider">
-                {data.data.map((block: Block) => (
+                {displayData.data.map((block: Block) => (
                   <tr key={block.id} className="bg-gradient-to-r from-[#161a29] to-[#19191e]/60 hover:bg-gradient-to-r hover:from-[#202538]/70 hover:to-[#242731]/70 transition-colors">
                     <td className="py-3 px-6 text-sm font-medium text-white">{block.number}</td>
                     <td className="py-3 px-6 text-sm text-white">{block.blobCount}</td>

--- a/src/components/LiveMetrics.tsx
+++ b/src/components/LiveMetrics.tsx
@@ -7,14 +7,21 @@ import { api } from '../lib/api';
 import { StatsResponse } from '../types';
 import DataStateWrapper from './DataStateWrapper';
 import { useNetwork } from '../hooks/useNetwork';
+import { useBlobWebSocket } from '../contexts/LiveDataContext';
+import { transformStatsResponse } from '../lib/api/stats';
 
 export default function LiveMetrics() {
   const { selectedNetwork } = useNetwork();
+  const { latestEvents } = useBlobWebSocket();
 
   // Fetch stats data from API
   const { data, isLoading, error } = useApiData<StatsResponse>(
     () => api.getStats(selectedNetwork.apiParam)
   );
+  const liveStatsData = latestEvents.stats_update
+    ? transformStatsResponse(latestEvents.stats_update.data)
+    : undefined;
+  const displayData = liveStatsData || data;
 
   // Transform API data into metrics format
   const getMetricsFromData = (statsData: StatsResponse) => {
@@ -70,13 +77,13 @@ export default function LiveMetrics() {
       <h2 className="text-2xl font-windsor-bold text-white mb-4">Live Metrics</h2>
 
       <DataStateWrapper
-        isLoading={isLoading}
-        error={error}
+        isLoading={isLoading && !displayData}
+        error={displayData ? null : error}
         loadingComponent={loadingComponent}
       >
-        {data && (
+        {displayData && (
           <div className="grid grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {getMetricsFromData(data).map((metric, index) => (
+            {getMetricsFromData(displayData).map((metric, index) => (
               <MetricCard
                 key={index}
                 title={metric.title}

--- a/src/components/MempoolTable.tsx
+++ b/src/components/MempoolTable.tsx
@@ -6,13 +6,40 @@ import { api } from '../lib/api';
 import { MempoolResponse, MempoolTransaction } from '../types';
 import DataStateWrapper from './DataStateWrapper';
 import { useNetwork } from '../hooks/useNetwork';
+import { useBlobWebSocket } from '../contexts/LiveDataContext';
+import { transformBlobToMempoolTransaction } from '../lib/api/mempool';
 
 export default function MempoolTable() {
   const { selectedNetwork } = useNetwork();
+  const { latestEvents } = useBlobWebSocket();
 
   const { data, isLoading, error } = useApiData<MempoolResponse>(
     () => api.getMempool(10, selectedNetwork.apiParam)
   );
+  const displayData = React.useMemo<MempoolResponse | undefined>(() => {
+    const liveEvent = latestEvents.mempool_update;
+    if (!liveEvent) {
+      return data;
+    }
+
+    if (liveEvent.data.action === 'remove') {
+      return {
+        data: (data?.data || [])
+          .filter((tx) => tx.txHash !== liveEvent.data.blob.tx_hash)
+          .map((tx, index) => ({ ...tx, id: index + 1 })),
+      };
+    }
+
+    const liveTransaction = transformBlobToMempoolTransaction(liveEvent.data.blob, 0);
+    return {
+      data: [
+        liveTransaction,
+        ...(data?.data || []).filter((tx) => tx.txHash !== liveTransaction.txHash),
+      ]
+        .slice(0, 10)
+        .map((tx, index) => ({ ...tx, id: index + 1 })),
+    };
+  }, [data, latestEvents.mempool_update]);
 
   // Loading state for the table
   const loadingComponent = (
@@ -70,11 +97,11 @@ export default function MempoolTable() {
       <h2 className="text-2xl font-windsor-bold text-white mb-4">Mempool Attribution</h2>
 
       <DataStateWrapper
-        isLoading={isLoading}
-        error={error}
+        isLoading={isLoading && !displayData}
+        error={displayData ? null : error}
         loadingComponent={loadingComponent}
       >
-        {data && (
+        {displayData && (
           <div className="overflow-x-auto border border-divider rounded-lg">
             <table className="min-w-full overflow-hidden table-fixed">
               <thead>
@@ -88,7 +115,7 @@ export default function MempoolTable() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-divider">
-                {data.data.map((tx: MempoolTransaction) => (
+                {displayData.data.map((tx: MempoolTransaction) => (
                   <tr key={tx.id} className="bg-gradient-to-r from-[#161a29] to-[#19191e]/60 hover:bg-gradient-to-r hover:from-[#202538]/70 hover:to-[#242731]/70 transition-colors">
                     <td className="py-3 px-6 text-sm font-mono text-white">{truncateTxHash(tx.txHash)}</td>
                     <td className="py-3 px-6 text-sm font-mono text-white">{tx.fromAddress}</td>

--- a/src/components/TopUsersTable.tsx
+++ b/src/components/TopUsersTable.tsx
@@ -7,14 +7,20 @@ import { api } from '../lib/api';
 import { TopUsersResponse, User } from '../types';
 import DataStateWrapper from './DataStateWrapper';
 import { useNetwork } from '../hooks/useNetwork';
+import { useBlobWebSocket } from '../contexts/LiveDataContext';
+import { transformUserResponses } from '../lib/api/users';
 
 export default function TopUsersTable() {
   const router = useRouter();
   const { selectedNetwork } = useNetwork();
+  const { latestEvents } = useBlobWebSocket();
 
   const { data, isLoading, error } = useApiData<TopUsersResponse>(
     () => api.getTopUsers(10, selectedNetwork.apiParam)
   );
+  const displayData = latestEvents.users_update
+    ? transformUserResponses(latestEvents.users_update.data)
+    : data;
 
   useEffect(() => {
     // Function to set up event listeners for tooltips
@@ -185,11 +191,11 @@ export default function TopUsersTable() {
       <h2 className="text-2xl font-windsor-bold text-white mb-4">Top Blob Users</h2>
 
       <DataStateWrapper
-        isLoading={isLoading}
-        error={error}
+        isLoading={isLoading && !displayData}
+        error={displayData ? null : error}
         loadingComponent={loadingComponent}
       >
-        {data && (
+        {displayData && (
           <div className="overflow-x-auto border border-divider rounded-lg">
             <table className="min-w-full overflow-hidden table-fixed">
               <thead>
@@ -207,7 +213,7 @@ export default function TopUsersTable() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-divider">
-                {data.data.map((user: User) => (
+                {displayData.data.map((user: User) => (
                   <tr
                     key={user.id}
                     className="bg-gradient-to-r from-[#161a29] to-[#19191e]/60 hover:bg-gradient-to-r hover:from-[#202538]/70 hover:to-[#242731]/70 transition-colors cursor-pointer"

--- a/src/components/TopUsersTable.tsx
+++ b/src/components/TopUsersTable.tsx
@@ -215,7 +215,7 @@ export default function TopUsersTable() {
               <tbody className="divide-y divide-divider">
                 {displayData.data.map((user: User) => (
                   <tr
-                    key={user.id}
+                    key={user.address}
                     className="bg-gradient-to-r from-[#161a29] to-[#19191e]/60 hover:bg-gradient-to-r hover:from-[#202538]/70 hover:to-[#242731]/70 transition-colors cursor-pointer"
                     onClick={() => router.push(`/user/${user.address}`)}
                   >

--- a/src/contexts/LiveDataContext.tsx
+++ b/src/contexts/LiveDataContext.tsx
@@ -57,7 +57,14 @@ export function LiveDataProvider({
     useState<BlobWebSocketConnectionState>('connecting');
   const [lastEvent, setLastEvent] = useState<LiveBlobWebSocketEvent | null>(null);
   const [latestEvents, setLatestEvents] = useState<LatestBlobWebSocketEvents>({});
-  const subscriptionKey = subscriptions.join(',');
+  const subscriptionKey = normalizeSubscriptions(subscriptions).join(',');
+  const normalizedSubscriptions = useMemo<SubscribableBlobEventType[]>(() => {
+    if (!subscriptionKey) {
+      return [];
+    }
+
+    return subscriptionKey.split(',') as SubscribableBlobEventType[];
+  }, [subscriptionKey]);
 
   const subscribe = useCallback((handler: LiveBlobEventHandler) => {
     handlersRef.current.add(handler);
@@ -70,7 +77,7 @@ export function LiveDataProvider({
   useEffect(() => {
     const client = new BlobWebSocketClient({
       url: buildBlobWebSocketUrl(network),
-      subscriptions,
+      subscriptions: normalizedSubscriptions,
       onConnectionStateChange: setConnectionState,
       onEvent: (event) => {
         setLastEvent(event);
@@ -94,7 +101,7 @@ export function LiveDataProvider({
     return () => {
       client.disconnect();
     };
-  }, [network, subscriptionKey, subscriptions]);
+  }, [network, normalizedSubscriptions]);
 
   const value = useMemo<LiveDataContextValue>(
     () => ({
@@ -131,4 +138,8 @@ export function useLiveBlobEvent<EventType extends SubscribableBlobEventType>(
       }
     });
   }, [eventType, subscribe]);
+}
+
+function normalizeSubscriptions(subscriptions: SubscribableBlobEventType[]) {
+  return Array.from(new Set(subscriptions)).sort();
 }

--- a/src/contexts/LiveDataContext.tsx
+++ b/src/contexts/LiveDataContext.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import React, {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  BlobWebSocketConnectionState,
+  BlobWebSocketEventMap,
+  LatestBlobWebSocketEvents,
+  LiveBlobWebSocketEvent,
+  SubscribableBlobEventType,
+} from '@/types';
+import {
+  BlobWebSocketClient,
+  DEFAULT_BLOB_WEBSOCKET_SUBSCRIPTIONS,
+  buildBlobWebSocketUrl,
+} from '@/lib/blobWebSocket';
+
+type LiveBlobEventHandler = (event: LiveBlobWebSocketEvent) => void;
+
+interface LiveDataContextValue {
+  connectionState: BlobWebSocketConnectionState;
+  lastEvent: LiveBlobWebSocketEvent | null;
+  latestEvents: LatestBlobWebSocketEvents;
+  subscribe: (handler: LiveBlobEventHandler) => () => void;
+}
+
+interface LiveDataProviderProps {
+  children: ReactNode;
+  network: string;
+  subscriptions?: SubscribableBlobEventType[];
+}
+
+const defaultContextValue: LiveDataContextValue = {
+  connectionState: 'disconnected',
+  lastEvent: null,
+  latestEvents: {},
+  subscribe: () => () => {},
+};
+
+const LiveDataContext = createContext<LiveDataContextValue>(defaultContextValue);
+
+export function LiveDataProvider({
+  children,
+  network,
+  subscriptions = DEFAULT_BLOB_WEBSOCKET_SUBSCRIPTIONS,
+}: LiveDataProviderProps) {
+  const handlersRef = useRef(new Set<LiveBlobEventHandler>());
+  const [connectionState, setConnectionState] =
+    useState<BlobWebSocketConnectionState>('connecting');
+  const [lastEvent, setLastEvent] = useState<LiveBlobWebSocketEvent | null>(null);
+  const [latestEvents, setLatestEvents] = useState<LatestBlobWebSocketEvents>({});
+  const subscriptionKey = subscriptions.join(',');
+
+  const subscribe = useCallback((handler: LiveBlobEventHandler) => {
+    handlersRef.current.add(handler);
+
+    return () => {
+      handlersRef.current.delete(handler);
+    };
+  }, []);
+
+  useEffect(() => {
+    const client = new BlobWebSocketClient({
+      url: buildBlobWebSocketUrl(network),
+      subscriptions,
+      onConnectionStateChange: setConnectionState,
+      onEvent: (event) => {
+        setLastEvent(event);
+        setLatestEvents((currentEvents) => ({
+          ...currentEvents,
+          [event.type]: event,
+        }));
+        handlersRef.current.forEach((handler) => {
+          handler(event);
+        });
+      },
+      onError: () => {
+        setConnectionState((currentState) =>
+          currentState === 'connected' ? 'stale' : currentState
+        );
+      },
+    });
+
+    client.connect();
+
+    return () => {
+      client.disconnect();
+    };
+  }, [network, subscriptionKey, subscriptions]);
+
+  const value = useMemo<LiveDataContextValue>(
+    () => ({
+      connectionState,
+      lastEvent,
+      latestEvents,
+      subscribe,
+    }),
+    [connectionState, lastEvent, latestEvents, subscribe]
+  );
+
+  return <LiveDataContext.Provider value={value}>{children}</LiveDataContext.Provider>;
+}
+
+export function useBlobWebSocket() {
+  return useContext(LiveDataContext);
+}
+
+export function useLiveBlobEvent<EventType extends SubscribableBlobEventType>(
+  eventType: EventType,
+  handler: (event: BlobWebSocketEventMap[EventType]) => void
+) {
+  const { subscribe } = useBlobWebSocket();
+  const handlerRef = useRef(handler);
+
+  useEffect(() => {
+    handlerRef.current = handler;
+  }, [handler]);
+
+  useEffect(() => {
+    return subscribe((event) => {
+      if (event.type === eventType) {
+        handlerRef.current(event as BlobWebSocketEventMap[EventType]);
+      }
+    });
+  }, [eventType, subscribe]);
+}

--- a/src/lib/api/blocks.ts
+++ b/src/lib/api/blocks.ts
@@ -1,5 +1,45 @@
-import { Block, LatestBlocksResponse, ApiResponse, BlobResponse } from '../../types';
+import { Block, LatestBlocksResponse, ApiResponse, BlobResponse, NewBlockData } from '../../types';
 import { fetchApi, formatRelativeTime } from './core';
+
+export function transformNewBlockData(blockData: NewBlockData): Block {
+    const attributions: string[] = Array.from(new Set(
+        blockData.blobs
+            .map(blob => blob.user_attribution)
+            .filter((attr): attr is string => Boolean(attr))
+    ));
+
+    return {
+        id: blockData.block_number,
+        number: blockData.block_number.toString(),
+        blobCount: blockData.blob_count,
+        timestamp: formatRelativeTime(blockData.timestamp),
+        attribution: attributions.length > 0 ? attributions : ['Unknown']
+    };
+}
+
+export function transformBlobResponsesToBlocks(blobsResponse: BlobResponse[]): LatestBlocksResponse {
+    // Group blobs by block number
+    const blockMap = new Map<string, { blobs: BlobResponse[]; firstSeen: string }>();
+    for (const blob of blobsResponse) {
+        const blockNum = blob.block_number.toString();
+        if (!blockMap.has(blockNum)) {
+            blockMap.set(blockNum, { blobs: [], firstSeen: blob.timestamp });
+        }
+        blockMap.get(blockNum)!.blobs.push(blob);
+    }
+
+    // Convert to Block[] for display
+    const blocks: Block[] = Array.from(blockMap.entries()).map(([blockNum, { blobs, firstSeen }]) => {
+        return transformNewBlockData({
+            block_number: Number(blockNum),
+            blob_count: blobs.length,
+            timestamp: firstSeen,
+            blobs
+        });
+    });
+
+    return { data: blocks };
+}
 
 /**
  * Get latest confirmed blobs and group them by block
@@ -9,34 +49,7 @@ import { fetchApi, formatRelativeTime } from './core';
 export async function getLatestBlocks(limit = 20, network?: string): Promise<LatestBlocksResponse> {
     const response = await fetchApi<ApiResponse<BlobResponse[]>>(`/blob/latest?limit=${limit}`, network);
 
-    // Group blobs by block number
-    const blockMap = new Map<string, { blobs: BlobResponse[]; firstSeen: string }>();
-    for (const blob of response.data) {
-        const blockNum = blob.block_number.toString();
-        if (!blockMap.has(blockNum)) {
-            blockMap.set(blockNum, { blobs: [], firstSeen: blob.timestamp });
-        }
-        blockMap.get(blockNum)!.blobs.push(blob);
-    }
-
-    // Convert to Block[] for display
-    const blocks: Block[] = Array.from(blockMap.entries()).map(([blockNum, { blobs, firstSeen }], index) => {
-        const attributions: string[] = Array.from(new Set(
-            blobs
-                .map(b => b.user_attribution)
-                .filter((attr): attr is string => Boolean(attr))
-        ));
-
-        return {
-            id: index + 1,
-            number: blockNum,
-            blobCount: blobs.length,
-            timestamp: formatRelativeTime(firstSeen),
-            attribution: attributions.length > 0 ? attributions : ['Unknown']
-        };
-    });
-
-    return { data: blocks };
+    return transformBlobResponsesToBlocks(response.data);
 }
 
 /**

--- a/src/lib/api/mempool.test.ts
+++ b/src/lib/api/mempool.test.ts
@@ -1,4 +1,4 @@
-import { getMempool } from './mempool';
+import { getMempool, transformBlobToMempoolTransaction } from './mempool';
 
 const originalFetch = global.fetch;
 
@@ -50,5 +50,27 @@ describe('api/mempool', () => {
       timeInMempool: '5 min ago',
     });
     expect(result.data[0].estimatedCost).toContain('Gwei');
+  });
+
+  it('formats decimal total_cost_eth values as ETH', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:05:00.000Z'));
+
+    const result = transformBlobToMempoolTransaction({
+      network_id: 1,
+      network_name: 'mainnet',
+      block_number: 0,
+      blob_index: 0,
+      tx_hash: '0xabc',
+      from_address: '0x1234567890abcdef',
+      blob_size_bytes: 131072,
+      base_fee_per_blob_gas: '1000000000',
+      tip_per_blob_gas: '0',
+      total_cost_eth: '0.001',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      confirmed: false,
+    }, 0);
+
+    expect(result.estimatedCost).toBe('0.001 ETH');
   });
 });

--- a/src/lib/api/mempool.ts
+++ b/src/lib/api/mempool.ts
@@ -1,6 +1,6 @@
 import { MempoolResponse, MempoolTransaction, ApiResponse, BlobResponse } from '../../types';
 import { fetchApi, formatRelativeTime, truncateAddress } from './core';
-import { formatWeiToReadable } from '../../utils';
+import { formatCostEthOrWei } from '../../utils';
 
 export function transformBlobToMempoolTransaction(blob: BlobResponse, index: number): MempoolTransaction {
     return {
@@ -9,7 +9,7 @@ export function transformBlobToMempoolTransaction(blob: BlobResponse, index: num
         fromAddress: truncateAddress(blob.from_address),
         user: blob.user_attribution || null,
         blobCount: 1,
-        estimatedCost: formatBlobCost(blob.total_cost_eth),
+        estimatedCost: formatCostEthOrWei(blob.total_cost_eth),
         timeInMempool: formatRelativeTime(blob.timestamp)
     };
 }
@@ -19,14 +19,6 @@ export function transformBlobResponsesToMempool(blobsResponse: BlobResponse[]): 
     const transactions: MempoolTransaction[] = blobsResponse.map(transformBlobToMempoolTransaction);
 
     return { data: transactions };
-}
-
-function formatBlobCost(costEthOrWei: string) {
-    if (costEthOrWei.includes('.')) {
-        return `${costEthOrWei} ETH`;
-    }
-
-    return formatWeiToReadable(costEthOrWei);
 }
 
 /**

--- a/src/lib/api/mempool.ts
+++ b/src/lib/api/mempool.ts
@@ -2,6 +2,33 @@ import { MempoolResponse, MempoolTransaction, ApiResponse, BlobResponse } from '
 import { fetchApi, formatRelativeTime, truncateAddress } from './core';
 import { formatWeiToReadable } from '../../utils';
 
+export function transformBlobToMempoolTransaction(blob: BlobResponse, index: number): MempoolTransaction {
+    return {
+        id: index + 1,
+        txHash: blob.tx_hash,
+        fromAddress: truncateAddress(blob.from_address),
+        user: blob.user_attribution || null,
+        blobCount: 1,
+        estimatedCost: formatBlobCost(blob.total_cost_eth),
+        timeInMempool: formatRelativeTime(blob.timestamp)
+    };
+}
+
+export function transformBlobResponsesToMempool(blobsResponse: BlobResponse[]): MempoolResponse {
+    // Map the API response to our expected format
+    const transactions: MempoolTransaction[] = blobsResponse.map(transformBlobToMempoolTransaction);
+
+    return { data: transactions };
+}
+
+function formatBlobCost(costEthOrWei: string) {
+    if (costEthOrWei.includes('.')) {
+        return `${costEthOrWei} ETH`;
+    }
+
+    return formatWeiToReadable(costEthOrWei);
+}
+
 /**
  * Get mempool data (pending blob transactions)
  * @param limit - Number of blobs to fetch
@@ -10,18 +37,5 @@ import { formatWeiToReadable } from '../../utils';
 export async function getMempool(limit = 10, network?: string): Promise<MempoolResponse> {
     const response = await fetchApi<ApiResponse<BlobResponse[]>>(`/blob/mempool?limit=${limit}`, network);
 
-    // Map the API response to our expected format
-    const transactions: MempoolTransaction[] = response.data.map((blob: BlobResponse, index: number) => {
-        return {
-            id: index + 1,
-            txHash: blob.tx_hash,
-            fromAddress: truncateAddress(blob.from_address),
-            user: blob.user_attribution || null,
-            blobCount: 1,
-            estimatedCost: formatWeiToReadable(blob.total_cost_eth),
-            timeInMempool: formatRelativeTime(blob.timestamp)
-        };
-    });
-
-    return { data: transactions };
+    return transformBlobResponsesToMempool(response.data);
 }

--- a/src/lib/api/stats.test.ts
+++ b/src/lib/api/stats.test.ts
@@ -1,4 +1,4 @@
-import { getStats } from './stats';
+import { getStats, transformStatsResponse } from './stats';
 
 const originalFetch = global.fetch;
 
@@ -41,5 +41,21 @@ describe('api/stats', () => {
       lastIndexedBlock: 12345,
     });
     expect(result.data.averageBaseFee).toContain('Gwei');
+  });
+
+  it('formats websocket decimal average total cost as ETH', () => {
+    const result = transformStatsResponse({
+      total_blobs: 100,
+      total_confirmed_blobs: 80,
+      total_pending_blobs: 20,
+      average_base_fee: '5014755072.74762611',
+      average_tip: '2000000000',
+      average_total_cost: '0.001',
+      last_indexed_block: 12345,
+      last_indexed_time: '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(result.data.averageBaseFee).toContain('Gwei');
+    expect(result.data.averageTotalCost).toBe('0.001 ETH');
   });
 });

--- a/src/lib/api/stats.ts
+++ b/src/lib/api/stats.ts
@@ -1,6 +1,6 @@
 import { StatsResponse, ApiResponse, BackendStatsResponse, WebSocketStatsResponse } from '../../types';
 import { fetchApi } from './core';
-import { formatWeiToReadable } from '../../utils';
+import { formatCostEthOrWei, formatWeiToReadable } from '../../utils';
 
 export function transformStatsResponse(stats: BackendStatsResponse | WebSocketStatsResponse): StatsResponse {
     return {
@@ -11,19 +11,11 @@ export function transformStatsResponse(stats: BackendStatsResponse | WebSocketSt
             pendingBlobsCount: stats.total_pending_blobs,
             avgBlobsPerBlock: Math.round(((stats.total_confirmed_blobs || 100) / 100) * 10) / 10,
             averageTip: formatWeiToReadable(stats.average_tip || '0'),
-            averageTotalCost: formatAverageTotalCost(stats.average_total_cost || '0'),
+            averageTotalCost: formatCostEthOrWei(stats.average_total_cost || '0'),
             lastIndexedBlock: stats.last_indexed_block,
             lastIndexedTime: stats.last_indexed_time
         }
     };
-}
-
-function formatAverageTotalCost(costEthOrWei: string) {
-    if (costEthOrWei.includes('.')) {
-        return `${costEthOrWei} ETH`;
-    }
-
-    return formatWeiToReadable(costEthOrWei);
 }
 
 /**

--- a/src/lib/api/stats.ts
+++ b/src/lib/api/stats.ts
@@ -1,16 +1,8 @@
-import { StatsResponse, ApiResponse, BackendStatsResponse } from '../../types';
+import { StatsResponse, ApiResponse, BackendStatsResponse, WebSocketStatsResponse } from '../../types';
 import { fetchApi } from './core';
 import { formatWeiToReadable } from '../../utils';
 
-/**
- * Get network stats data
- * @param network - Optional network parameter
- */
-export async function getStats(network?: string): Promise<StatsResponse> {
-    const response = await fetchApi<ApiResponse<BackendStatsResponse>>(`/stats`, network);
-
-    const stats = response.data;
-
+export function transformStatsResponse(stats: BackendStatsResponse | WebSocketStatsResponse): StatsResponse {
     return {
         data: {
             averageBaseFee: formatWeiToReadable(stats.average_base_fee || '0'),
@@ -19,9 +11,27 @@ export async function getStats(network?: string): Promise<StatsResponse> {
             pendingBlobsCount: stats.total_pending_blobs,
             avgBlobsPerBlock: Math.round(((stats.total_confirmed_blobs || 100) / 100) * 10) / 10,
             averageTip: formatWeiToReadable(stats.average_tip || '0'),
-            averageTotalCost: formatWeiToReadable(stats.average_total_cost || '0'),
+            averageTotalCost: formatAverageTotalCost(stats.average_total_cost || '0'),
             lastIndexedBlock: stats.last_indexed_block,
             lastIndexedTime: stats.last_indexed_time
         }
     };
+}
+
+function formatAverageTotalCost(costEthOrWei: string) {
+    if (costEthOrWei.includes('.')) {
+        return `${costEthOrWei} ETH`;
+    }
+
+    return formatWeiToReadable(costEthOrWei);
+}
+
+/**
+ * Get network stats data
+ * @param network - Optional network parameter
+ */
+export async function getStats(network?: string): Promise<StatsResponse> {
+    const response = await fetchApi<ApiResponse<BackendStatsResponse>>(`/stats`, network);
+
+    return transformStatsResponse(response.data);
 }

--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -2,19 +2,12 @@ import { TopUsersResponse, User, ApiResponse, UserResponse, BlobResponse } from 
 import { fetchApi } from './core';
 import { truncateAddress } from '../../utils';
 
-/**
- * Get top blob users
- * @param limit - Number of users to return
- * @param network - Optional network parameter
- */
-export const getTopUsers = async (limit = 10, network?: string): Promise<TopUsersResponse> => {
-    const response = await fetchApi<ApiResponse<UserResponse[]>>(`/users?limit=${limit}`, network);
-
+export function transformUserResponses(usersResponse: UserResponse[]): TopUsersResponse {
     // Calculate total blobs across all returned users for percentage calculation
-    const totalBlobs = response.data.reduce((sum, user) => sum + user.blob_count, 0) || 1;
+    const totalBlobs = usersResponse.reduce((sum, user) => sum + user.blob_count, 0) || 1;
 
     // Map the API response to our expected format
-    const users: User[] = response.data.map((user: UserResponse, index: number) => {
+    const users: User[] = usersResponse.map((user: UserResponse, index: number) => {
         const percentage = Math.round((user.blob_count / totalBlobs) * 1000) / 10;
 
         return {
@@ -29,6 +22,17 @@ export const getTopUsers = async (limit = 10, network?: string): Promise<TopUser
     });
 
     return { data: users };
+}
+
+/**
+ * Get top blob users
+ * @param limit - Number of users to return
+ * @param network - Optional network parameter
+ */
+export const getTopUsers = async (limit = 10, network?: string): Promise<TopUsersResponse> => {
+    const response = await fetchApi<ApiResponse<UserResponse[]>>(`/users?limit=${limit}`, network);
+
+    return transformUserResponses(response.data);
 };
 
 /**

--- a/src/lib/blobWebSocket.test.ts
+++ b/src/lib/blobWebSocket.test.ts
@@ -1,0 +1,219 @@
+import {
+  BlobWebSocketClient,
+  WebSocketLike,
+  buildBlobWebSocketUrl,
+  createBlobWebSocketSubscribeMessage,
+  parseBlobWebSocketEvent,
+} from './blobWebSocket';
+import { BlobResponse, LiveBlobWebSocketEvent } from '@/types';
+
+class MockWebSocket implements WebSocketLike {
+  static instances: MockWebSocket[] = [];
+
+  readyState = 0;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  readonly sentMessages: string[] = [];
+
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    this.sentMessages.push(data);
+  }
+
+  close() {
+    this.readyState = 3;
+  }
+
+  open() {
+    this.readyState = 1;
+    this.onopen?.(new Event('open'));
+  }
+
+  receive(data: string) {
+    this.onmessage?.({ data } as MessageEvent<string>);
+  }
+
+  closeFromServer() {
+    this.readyState = 3;
+    this.onclose?.(new CloseEvent('close'));
+  }
+}
+
+const blobResponse: BlobResponse = {
+  network_id: 1,
+  network_name: 'mainnet',
+  block_number: 123,
+  blob_index: 0,
+  tx_hash: '0xabc123',
+  from_address: '0x0000000000000000000000000000000000000000',
+  blob_size_bytes: 131072,
+  base_fee_per_blob_gas: '1000000000',
+  tip_per_blob_gas: '100000000',
+  total_cost_eth: '0.001',
+  timestamp: '2026-03-09T14:00:00Z',
+  confirmed: true,
+};
+
+describe('blobWebSocket', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('derives websocket URLs from API URLs and preserves explicit overrides', () => {
+    expect(
+      buildBlobWebSocketUrl('mainnet', 'https://blob-indexer.ahkc.win/api/v1', undefined)
+    ).toBe('wss://blob-indexer.ahkc.win/api/v1/ws?network=mainnet');
+
+    expect(buildBlobWebSocketUrl('sepolia', 'http://localhost:8080/api/v1', undefined)).toBe(
+      'ws://localhost:8080/api/v1/ws?network=sepolia'
+    );
+
+    expect(
+      buildBlobWebSocketUrl(
+        'mainnet',
+        'https://ignored.example/api/v1',
+        'wss://stream.example/ws?token=abc'
+      )
+    ).toBe('wss://stream.example/ws?token=abc&network=mainnet');
+  });
+
+  it('builds subscription filter messages without duplicates', () => {
+    expect(createBlobWebSocketSubscribeMessage(['new_block', 'new_block', 'stats_update'])).toEqual({
+      subscribe: ['new_block', 'stats_update'],
+    });
+  });
+
+  it('parses known events and ignores invalid messages', () => {
+    expect(parseBlobWebSocketEvent('not json')).toBeNull();
+    expect(parseBlobWebSocketEvent(JSON.stringify({ type: 'unknown' }))).toBeNull();
+    expect(parseBlobWebSocketEvent(JSON.stringify({ type: 'ping' }))).toEqual({ type: 'ping' });
+
+    const parsed = parseBlobWebSocketEvent(
+      JSON.stringify({
+        type: 'new_block',
+        data: {
+          block_number: 123,
+          blob_count: 1,
+          timestamp: '2026-03-09T14:00:00Z',
+          blobs: [blobResponse],
+        },
+      })
+    );
+
+    expect(parsed?.type).toBe('new_block');
+    if (parsed?.type === 'new_block') {
+      expect(parsed.data.blob_count).toBe(1);
+      expect(parsed.data.blobs[0].tx_hash).toBe('0xabc123');
+    }
+  });
+
+  it('opens one active socket and sends subscription filters after connect', () => {
+    const states: string[] = [];
+    const client = new BlobWebSocketClient({
+      url: 'wss://example.test/api/v1/ws?network=mainnet',
+      subscriptions: ['new_block', 'stats_update'],
+      WebSocketImpl: MockWebSocket,
+      onConnectionStateChange: (state) => states.push(state),
+    });
+
+    client.connect();
+    client.connect();
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    MockWebSocket.instances[0].open();
+
+    expect(states).toEqual(['connecting', 'connected']);
+    expect(MockWebSocket.instances[0].sentMessages).toEqual([
+      JSON.stringify({ subscribe: ['new_block', 'stats_update'] }),
+    ]);
+  });
+
+  it('does not surface ping events to consumers', () => {
+    const events: LiveBlobWebSocketEvent[] = [];
+    const client = new BlobWebSocketClient({
+      url: 'wss://example.test/api/v1/ws?network=mainnet',
+      WebSocketImpl: MockWebSocket,
+      onEvent: (event) => events.push(event),
+    });
+
+    client.connect();
+    MockWebSocket.instances[0].open();
+    MockWebSocket.instances[0].receive(JSON.stringify({ type: 'ping' }));
+    MockWebSocket.instances[0].receive(
+      JSON.stringify({
+        type: 'stats_update',
+        data: {
+          total_blobs: 10,
+          total_confirmed_blobs: 8,
+          total_pending_blobs: 2,
+          average_base_fee: '1000000000',
+          average_tip: '100000000',
+          average_total_cost: '0.001',
+          last_indexed_block: 123,
+          last_indexed_time: '2026-03-09T14:00:00Z',
+        },
+      })
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('stats_update');
+  });
+
+  it('marks open sockets stale when heartbeats stop and restores connected on messages', async () => {
+    vi.useFakeTimers();
+    const states: string[] = [];
+    const client = new BlobWebSocketClient({
+      url: 'wss://example.test/api/v1/ws?network=mainnet',
+      WebSocketImpl: MockWebSocket,
+      staleTimeoutMs: 50,
+      onConnectionStateChange: (state) => states.push(state),
+    });
+
+    client.connect();
+    MockWebSocket.instances[0].open();
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(states).toEqual(['connecting', 'connected', 'stale']);
+
+    MockWebSocket.instances[0].receive(JSON.stringify({ type: 'ping' }));
+
+    expect(states).toEqual(['connecting', 'connected', 'stale', 'connected']);
+  });
+
+  it('reconnects with capped backoff after unplanned closes', async () => {
+    vi.useFakeTimers();
+    const states: string[] = [];
+    const client = new BlobWebSocketClient({
+      url: 'wss://example.test/api/v1/ws?network=mainnet',
+      WebSocketImpl: MockWebSocket,
+      reconnectDelayMs: 10,
+      maxReconnectDelayMs: 15,
+      onConnectionStateChange: (state) => states.push(state),
+    });
+
+    client.connect();
+    MockWebSocket.instances[0].closeFromServer();
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+
+    MockWebSocket.instances[1].closeFromServer();
+    await vi.advanceTimersByTimeAsync(14);
+    expect(MockWebSocket.instances).toHaveLength(2);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(MockWebSocket.instances).toHaveLength(3);
+    expect(states).toEqual(['connecting', 'reconnecting']);
+  });
+});

--- a/src/lib/blobWebSocket.ts
+++ b/src/lib/blobWebSocket.ts
@@ -1,0 +1,319 @@
+import { API_BASE_URL } from '@/constants';
+import {
+  BlobWebSocketConnectionState,
+  BlobWebSocketEvent,
+  BlobWebSocketSubscribeMessage,
+  LiveBlobWebSocketEvent,
+  MempoolUpdateData,
+  NewBlockData,
+  SubscribableBlobEventType,
+  UserResponse,
+  WebSocketStatsResponse,
+} from '@/types';
+
+const SOCKET_CONNECTING = 0;
+const SOCKET_OPEN = 1;
+const DEFAULT_RECONNECT_DELAY_MS = 1000;
+const DEFAULT_MAX_RECONNECT_DELAY_MS = 30000;
+const DEFAULT_STALE_TIMEOUT_MS = 45000;
+
+export const DEFAULT_BLOB_WEBSOCKET_SUBSCRIPTIONS: SubscribableBlobEventType[] = [
+  'new_block',
+  'mempool_update',
+  'stats_update',
+  'users_update',
+];
+
+type WebSocketMessageHandler = (event: MessageEvent<string>) => void;
+type WebSocketCloseHandler = (event: CloseEvent) => void;
+type WebSocketEventHandler = (event: Event) => void;
+
+export interface WebSocketLike {
+  readyState: number;
+  onopen: WebSocketEventHandler | null;
+  onmessage: WebSocketMessageHandler | null;
+  onclose: WebSocketCloseHandler | null;
+  onerror: WebSocketEventHandler | null;
+  send: (data: string) => void;
+  close: () => void;
+}
+
+export interface WebSocketConstructorLike {
+  new (url: string): WebSocketLike;
+}
+
+interface BlobWebSocketClientOptions {
+  url: string;
+  subscriptions?: SubscribableBlobEventType[];
+  WebSocketImpl?: WebSocketConstructorLike;
+  reconnectDelayMs?: number;
+  maxReconnectDelayMs?: number;
+  staleTimeoutMs?: number;
+  onConnectionStateChange?: (state: BlobWebSocketConnectionState) => void;
+  onEvent?: (event: LiveBlobWebSocketEvent) => void;
+  onError?: (event: Event) => void;
+}
+
+export function buildBlobWebSocketUrl(
+  network: string,
+  apiBaseUrl = API_BASE_URL,
+  websocketUrlOverride = process.env.NEXT_PUBLIC_WS_URL
+): string {
+  const baseUrl = websocketUrlOverride || apiBaseUrl;
+  const url = new URL(baseUrl);
+
+  if (url.protocol === 'http:') {
+    url.protocol = 'ws:';
+  } else if (url.protocol === 'https:') {
+    url.protocol = 'wss:';
+  }
+
+  if (!websocketUrlOverride) {
+    url.pathname = `${url.pathname.replace(/\/$/, '')}/ws`;
+  }
+
+  url.searchParams.set('network', network);
+  return url.toString();
+}
+
+export function createBlobWebSocketSubscribeMessage(
+  subscriptions: SubscribableBlobEventType[] = DEFAULT_BLOB_WEBSOCKET_SUBSCRIPTIONS
+): BlobWebSocketSubscribeMessage {
+  return {
+    subscribe: Array.from(new Set(subscriptions)),
+  };
+}
+
+export function parseBlobWebSocketEvent(message: string): BlobWebSocketEvent | null {
+  let payload: unknown;
+
+  try {
+    payload = JSON.parse(message);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(payload) || typeof payload.type !== 'string') {
+    return null;
+  }
+
+  switch (payload.type) {
+    case 'ping':
+      return { type: 'ping' };
+    case 'new_block':
+      if (isRecord(payload.data)) {
+        return { type: 'new_block', data: payload.data as unknown as NewBlockData };
+      }
+      return null;
+    case 'mempool_update':
+      if (isMempoolUpdateData(payload.data)) {
+        return { type: 'mempool_update', data: payload.data };
+      }
+      return null;
+    case 'stats_update':
+      if (isRecord(payload.data)) {
+        return { type: 'stats_update', data: payload.data as unknown as WebSocketStatsResponse };
+      }
+      return null;
+    case 'users_update':
+      if (Array.isArray(payload.data)) {
+        return { type: 'users_update', data: payload.data.filter(isRecord) as unknown as UserResponse[] };
+      }
+      return null;
+    default:
+      return null;
+  }
+}
+
+export class BlobWebSocketClient {
+  private socket: WebSocketLike | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private staleTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempt = 0;
+  private closedByClient = false;
+  private connectionState: BlobWebSocketConnectionState = 'disconnected';
+
+  constructor(private readonly options: BlobWebSocketClientOptions) {}
+
+  connect() {
+    if (this.hasActiveSocket()) {
+      return;
+    }
+
+    const WebSocketImpl: WebSocketConstructorLike | undefined =
+      this.options.WebSocketImpl ?? globalThis.WebSocket;
+    if (!WebSocketImpl) {
+      this.setConnectionState('disconnected');
+      return;
+    }
+
+    this.closedByClient = false;
+    this.clearReconnectTimer();
+    this.setConnectionState(this.reconnectAttempt > 0 ? 'reconnecting' : 'connecting');
+
+    const socket = new WebSocketImpl(this.options.url);
+    this.socket = socket;
+
+    socket.onopen = () => {
+      if (this.socket !== socket) {
+        return;
+      }
+
+      this.reconnectAttempt = 0;
+      this.setConnectionState('connected');
+      this.resetStaleTimer();
+      this.sendSubscriptions();
+    };
+
+    socket.onmessage = (event) => {
+      if (this.socket !== socket) {
+        return;
+      }
+
+      this.resetStaleTimer();
+      const parsedEvent = parseBlobWebSocketEvent(event.data);
+      if (!parsedEvent || parsedEvent.type === 'ping') {
+        return;
+      }
+
+      this.options.onEvent?.(parsedEvent);
+    };
+
+    socket.onerror = (event) => {
+      if (this.socket !== socket) {
+        return;
+      }
+
+      this.options.onError?.(event);
+    };
+
+    socket.onclose = () => {
+      if (this.socket !== socket) {
+        return;
+      }
+
+      this.socket = null;
+      this.clearStaleTimer();
+
+      if (this.closedByClient) {
+        this.setConnectionState('disconnected');
+        return;
+      }
+
+      this.scheduleReconnect();
+    };
+  }
+
+  disconnect() {
+    this.closedByClient = true;
+    this.clearReconnectTimer();
+    this.clearStaleTimer();
+
+    const socket = this.socket;
+    this.socket = null;
+
+    if (socket) {
+      socket.onopen = null;
+      socket.onmessage = null;
+      socket.onclose = null;
+      socket.onerror = null;
+
+      if (socket.readyState === SOCKET_CONNECTING || socket.readyState === SOCKET_OPEN) {
+        socket.close();
+      }
+    }
+
+    this.setConnectionState('disconnected');
+  }
+
+  get state() {
+    return this.connectionState;
+  }
+
+  private hasActiveSocket() {
+    return (
+      this.socket !== null &&
+      (this.socket.readyState === SOCKET_CONNECTING || this.socket.readyState === SOCKET_OPEN)
+    );
+  }
+
+  private sendSubscriptions() {
+    if (!this.socket || this.socket.readyState !== SOCKET_OPEN) {
+      return;
+    }
+
+    const subscriptions = this.options.subscriptions ?? DEFAULT_BLOB_WEBSOCKET_SUBSCRIPTIONS;
+    if (subscriptions.length === 0) {
+      return;
+    }
+
+    this.socket.send(JSON.stringify(createBlobWebSocketSubscribeMessage(subscriptions)));
+  }
+
+  private scheduleReconnect() {
+    this.setConnectionState('reconnecting');
+
+    const baseDelay = this.options.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS;
+    const maxDelay = this.options.maxReconnectDelayMs ?? DEFAULT_MAX_RECONNECT_DELAY_MS;
+    const delay = Math.min(baseDelay * 2 ** this.reconnectAttempt, maxDelay);
+    this.reconnectAttempt += 1;
+
+    this.reconnectTimer = setTimeout(() => {
+      this.connect();
+    }, delay);
+  }
+
+  private resetStaleTimer() {
+    this.clearStaleTimer();
+
+    const staleTimeoutMs = this.options.staleTimeoutMs ?? DEFAULT_STALE_TIMEOUT_MS;
+    this.staleTimer = setTimeout(() => {
+      if (this.socket?.readyState === SOCKET_OPEN) {
+        this.setConnectionState('stale');
+      }
+    }, staleTimeoutMs);
+
+    if (this.connectionState === 'stale') {
+      this.setConnectionState('connected');
+    }
+  }
+
+  private setConnectionState(state: BlobWebSocketConnectionState) {
+    if (this.connectionState === state) {
+      return;
+    }
+
+    this.connectionState = state;
+    this.options.onConnectionStateChange?.(state);
+  }
+
+  private clearReconnectTimer() {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private clearStaleTimer() {
+    if (this.staleTimer) {
+      clearTimeout(this.staleTimer);
+      this.staleTimer = null;
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isMempoolUpdateData(value: unknown): value is MempoolUpdateData {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (value.action !== 'add' && value.action !== 'remove') {
+    return false;
+  }
+
+  return isRecord(value.blob) && typeof value.blob.tx_hash === 'string';
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,91 @@ export interface BlobResponse {
   blob_gas_used?: number;
 }
 
+// ---- WebSocket Live Data Types ----
+
+export type BlobWebSocketConnectionState =
+  | 'connecting'
+  | 'connected'
+  | 'stale'
+  | 'reconnecting'
+  | 'disconnected';
+
+export type SubscribableBlobEventType =
+  | 'new_block'
+  | 'mempool_update'
+  | 'stats_update'
+  | 'users_update';
+
+export type BlobWebSocketEventType = SubscribableBlobEventType | 'ping';
+
+export interface NewBlockData {
+  block_number: number;
+  blob_count: number;
+  timestamp: string;
+  blobs: BlobResponse[];
+}
+
+export interface NewBlockEvent {
+  type: 'new_block';
+  data: NewBlockData;
+}
+
+export type MempoolUpdateData =
+  | {
+      action: 'add';
+      blob: BlobResponse;
+    }
+  | {
+      action: 'remove';
+      blob: Pick<BlobResponse, 'network_id' | 'network_name' | 'tx_hash'>;
+    };
+
+export interface MempoolUpdateEvent {
+  type: 'mempool_update';
+  data: MempoolUpdateData;
+}
+
+export type WebSocketStatsResponse = Omit<BackendStatsResponse, 'network_id' | 'network_name'> &
+  Partial<Pick<BackendStatsResponse, 'network_id' | 'network_name'>>;
+
+export interface StatsUpdateEvent {
+  type: 'stats_update';
+  data: WebSocketStatsResponse;
+}
+
+export interface UsersUpdateEvent {
+  type: 'users_update';
+  data: UserResponse[];
+}
+
+export interface PingEvent {
+  type: 'ping';
+}
+
+export type BlobWebSocketEvent =
+  | NewBlockEvent
+  | MempoolUpdateEvent
+  | StatsUpdateEvent
+  | UsersUpdateEvent
+  | PingEvent;
+
+export type LiveBlobWebSocketEvent = Exclude<BlobWebSocketEvent, PingEvent>;
+
+export interface BlobWebSocketEventMap {
+  new_block: NewBlockEvent;
+  mempool_update: MempoolUpdateEvent;
+  stats_update: StatsUpdateEvent;
+  users_update: UsersUpdateEvent;
+}
+
+export type LatestBlobWebSocketEvents = {
+  [EventType in SubscribableBlobEventType]?: BlobWebSocketEventMap[EventType];
+};
+
+export interface BlobWebSocketSubscribeMessage {
+  subscribe: SubscribableBlobEventType[];
+}
+
 // Frontend Block type (transformed from BlobResponse for display)
 export interface Block {
   id: number;
@@ -66,12 +151,15 @@ export interface MempoolResponse {
 // Backend UserResponse - matches api.UserResponse from swagger
 export interface UserResponse {
   network_id: number;
-  network_name: string;
+  network_name?: string;
   address: string;
   name?: string;
+  category?: string;
   blob_count: number;
   total_cost_eth: string;
   last_timestamp: string;
+  blob_share_percent?: number;
+  spend_share_percent?: number;
 }
 
 // Frontend User type (transformed for display)

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,4 +1,10 @@
-import { formatDate, formatNumber, formatWeiToReadable, truncateAddress } from './index';
+import {
+  formatCostEthOrWei,
+  formatDate,
+  formatNumber,
+  formatWeiToReadable,
+  truncateAddress,
+} from './index';
 
 describe('utils', () => {
   it('formats numbers with locale separators', () => {
@@ -17,8 +23,18 @@ describe('utils', () => {
 
   it('formats wei values with appropriate unit', () => {
     expect(formatWeiToReadable('500')).toBe('500 Wei');
-    expect(formatWeiToReadable('1000000000')).toContain('Gwei');
-    expect(formatWeiToReadable('5014755072.74762611')).toContain('Gwei');
-    expect(formatWeiToReadable('1000000000000000000')).toContain('ETH');
+    expect(formatWeiToReadable('0.001')).toBe('0.001 Wei');
+    expect(formatWeiToReadable('1000000000')).toBe('1 Gwei');
+    expect(formatWeiToReadable('5014755072.74762611')).toBe('5.01475507274762611 Gwei');
+    expect(formatWeiToReadable('1000000000000000000')).toBe('1 ETH');
+  });
+
+  it('formats decimal ETH costs and integer wei costs', () => {
+    expect(formatCostEthOrWei('0.001')).toBe('0.001 ETH');
+    expect(formatCostEthOrWei('1000000000')).toBe('1 Gwei');
+  });
+
+  it('rejects invalid decimal values', () => {
+    expect(() => formatWeiToReadable('abc')).toThrow('Invalid decimal value');
   });
 });

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -18,6 +18,7 @@ describe('utils', () => {
   it('formats wei values with appropriate unit', () => {
     expect(formatWeiToReadable('500')).toBe('500 Wei');
     expect(formatWeiToReadable('1000000000')).toContain('Gwei');
+    expect(formatWeiToReadable('5014755072.74762611')).toContain('Gwei');
     expect(formatWeiToReadable('1000000000000000000')).toContain('ETH');
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,8 +1,6 @@
 /**
  * Utility functions for the application
  */
-import { formatUnits } from 'viem';
-
 export function formatNumber(num: number): string {
   return new Intl.NumberFormat().format(num);
 }
@@ -23,27 +21,73 @@ export function formatDate(date: Date): string {
 /**
  * Formats a wei value to a human-readable string with appropriate units
  * Automatically selects the best unit based on the value's size
- * @param weiValue - The value in wei as a string or number
+ * Fractional wei strings are preserved for aggregate values such as averages.
+ * @param weiValue - The value in wei as a decimal string or number
  * @returns Formatted string with appropriate unit
  */
 export function formatWeiToReadable(weiValue: string | number): string {
-  const rawWeiValue = typeof weiValue === 'string' ? weiValue : weiValue.toString();
-  const wholeWeiValue = rawWeiValue.split('.')[0] || '0';
-  const wei = BigInt(wholeWeiValue);
+  const rawWeiValue = normalizeDecimalString(weiValue);
+  const wholeWeiValue = rawWeiValue.split('.')[0];
+  const wholeWei = BigInt(wholeWeiValue);
 
   // Define thresholds for different units
   const GWEI_THRESHOLD = BigInt(1_000_000_000); // 10^9
   const ETHER_THRESHOLD = BigInt(1_000_000_000_000_000_000); // 10^18
 
   // Choose the appropriate unit based on the value's size
-  if (wei >= ETHER_THRESHOLD) {
+  if (wholeWei >= ETHER_THRESHOLD) {
     // Format as ETH (10^18)
-    return `${formatUnits(wei, 18)} ETH`;
-  } else if (wei >= GWEI_THRESHOLD) {
+    return `${formatDecimalUnits(rawWeiValue, 18)} ETH`;
+  } else if (wholeWei >= GWEI_THRESHOLD) {
     // Format as Gwei (10^9)
-    return `${formatUnits(wei, 9)} Gwei`;
+    return `${formatDecimalUnits(rawWeiValue, 9)} Gwei`;
   } else {
     // Format as Wei
-    return `${wei.toString()} Wei`;
+    return `${rawWeiValue} Wei`;
   }
+}
+
+export function formatCostEthOrWei(costEthOrWei: string | number): string {
+  const rawCost = normalizeDecimalString(costEthOrWei);
+
+  if (rawCost.includes('.')) {
+    return `${rawCost} ETH`;
+  }
+
+  return formatWeiToReadable(rawCost);
+}
+
+function normalizeDecimalString(value: string | number): string {
+  const rawValue = typeof value === 'string' ? value.trim() : value.toString();
+
+  if (!/^\d+(?:\.\d+)?$/.test(rawValue)) {
+    throw new Error(`Invalid decimal value: ${rawValue}`);
+  }
+
+  const [wholePart, fractionalPart] = rawValue.split('.');
+  const normalizedWhole = wholePart.replace(/^0+(?=\d)/, '');
+  const normalizedFractional = fractionalPart?.replace(/0+$/, '');
+
+  if (!normalizedFractional) {
+    return normalizedWhole;
+  }
+
+  return `${normalizedWhole}.${normalizedFractional}`;
+}
+
+function formatDecimalUnits(value: string, decimals: number): string {
+  const [wholePart, fractionalPart = ''] = value.split('.');
+  const digits = `${wholePart}${fractionalPart}`;
+  const decimalIndex = wholePart.length - decimals;
+
+  if (decimalIndex > 0) {
+    return trimTrailingZeros(`${digits.slice(0, decimalIndex)}.${digits.slice(decimalIndex)}`);
+  }
+
+  return trimTrailingZeros(`0.${'0'.repeat(Math.abs(decimalIndex))}${digits}`);
+}
+
+function trimTrailingZeros(value: string): string {
+  const trimmedValue = value.replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '');
+  return trimmedValue || '0';
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -27,8 +27,9 @@ export function formatDate(date: Date): string {
  * @returns Formatted string with appropriate unit
  */
 export function formatWeiToReadable(weiValue: string | number): string {
-  // Convert string to bigint if needed
-  const wei = typeof weiValue === 'string' ? BigInt(weiValue) : BigInt(weiValue.toString());
+  const rawWeiValue = typeof weiValue === 'string' ? weiValue : weiValue.toString();
+  const wholeWeiValue = rawWeiValue.split('.')[0] || '0';
+  const wei = BigInt(wholeWeiValue);
 
   // Define thresholds for different units
   const GWEI_THRESHOLD = BigInt(1_000_000_000); // 10^9


### PR DESCRIPTION
## Summary
- Add a typed WebSocket client for Blob Indexer live events, including URL derivation from `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_WS_URL` override support.
- Add a live data provider and hooks so consumers can read connection state and subscribe to typed events without touching `WebSocket`.
- Wire the dashboard shell/header and key dashboard sections to consume pushed stats, block, users, and mempool updates while keeping REST snapshots as the initial load path.
- Add focused tests for URL construction, event parsing, subscription messages, ping suppression, stale state, reconnect behavior, and live decimal value formatting.

## Validation
- `npm test`
- `npm run typecheck`
- `npm run lint` (passes with existing `<img>` warnings)
- `npm run build`
- Browser check on local Next dev server confirmed the header live status reaches `Connected` and the WebSocket decimal formatter crash is fixed.

Closes #44