### PR TITLE
fix: stop repeated live API fetches

### DIFF
--- a/src/app/user/[address]/page.tsx
+++ b/src/app/user/[address]/page.tsx
@@ -10,7 +10,7 @@ import { useApiData } from '@/hooks/useApiData';
 import { api } from '@/lib/api';
 import { useNetwork } from '@/hooks/useNetwork';
 import { UserResponse, BlobResponse } from '@/types';
-import { formatWeiToReadable, truncateAddress } from '@/utils';
+import { formatWeiToReadable, getAttributionImageSrc, getAttributionInitial, truncateAddress } from '@/utils';
 import { formatRelativeTime } from '@/lib/api/core';
 
 function BlobTable({ blobs, showBlock }: { blobs: BlobResponse[]; showBlock: boolean }) {
@@ -67,15 +67,21 @@ export default function UserDetailPage() {
   const { selectedNetwork } = useNetwork();
 
   const { data: user, isLoading: userLoading, error: userError } = useApiData<UserResponse>(
-    () => api.getUserByAddress(address, selectedNetwork.apiParam)
+    () => api.getUserByAddress(address, selectedNetwork.apiParam),
+    undefined,
+    `${selectedNetwork.apiParam}:${address}`
   );
 
   const { data: confirmedBlobs, isLoading: blobsLoading, error: blobsError } = useApiData<BlobResponse[]>(
-    () => api.getUserBlobs(address, true, 20, selectedNetwork.apiParam)
+    () => api.getUserBlobs(address, true, 20, selectedNetwork.apiParam),
+    undefined,
+    `${selectedNetwork.apiParam}:${address}`
   );
 
   const { data: mempoolBlobs, isLoading: mempoolLoading, error: mempoolError } = useApiData<BlobResponse[]>(
-    () => api.getUserBlobs(address, false, 20, selectedNetwork.apiParam)
+    () => api.getUserBlobs(address, false, 20, selectedNetwork.apiParam),
+    undefined,
+    `${selectedNetwork.apiParam}:${address}`
   );
 
   const userName = user?.name || truncateAddress(address);
@@ -140,10 +146,12 @@ export default function UserDetailPage() {
           {user && (
             <div className="mb-8">
               <div className="flex items-center gap-3 mb-3">
-                {user.name && !user.name.includes('...') ? (
-                  <img src={`/images/${user.name.toLowerCase()}.png`} alt={user.name} className="w-8 h-8" />
+                {user.name && getAttributionImageSrc(user.name) ? (
+                  <img src={getAttributionImageSrc(user.name) || ''} alt={user.name} className="w-8 h-8" />
                 ) : (
-                  <span className="w-8 h-8 rounded-full bg-gray-500 inline-block" />
+                  <span className="w-8 h-8 rounded-full bg-gray-500 inline-flex items-center justify-center text-sm text-white font-medium">
+                    {getAttributionInitial(userName)}
+                  </span>
                 )}
                 <h1 className="text-3xl font-windsor-bold text-white">{userName}</h1>
               </div>

--- a/src/components/LatestBlocksTable.tsx
+++ b/src/components/LatestBlocksTable.tsx
@@ -6,12 +6,15 @@ import { api } from '../lib/api';
 import { Block, LatestBlocksResponse } from '../types';
 import DataStateWrapper from './DataStateWrapper';
 import { useNetwork } from '../hooks/useNetwork';
+import { getAttributionImageSrc, getAttributionInitial } from '../utils';
 
 export default function LatestBlocksTable() {
   const { selectedNetwork } = useNetwork();
 
   const { data, isLoading, error } = useApiData<LatestBlocksResponse>(
-    () => api.getLatestBlocks(20, selectedNetwork.apiParam)
+    () => api.getLatestBlocks(20, selectedNetwork.apiParam),
+    undefined,
+    selectedNetwork.apiParam
   );
 
   // Loading state for the table
@@ -86,25 +89,43 @@ export default function LatestBlocksTable() {
                     <td className="py-3 px-6 text-sm text-white">
                       {block.attribution.length === 1 ? (
                         <div className="flex items-center">
-                          <img
-                            src={`/images/${block.attribution[0].toLowerCase()}.png`}
-                            alt={block.attribution[0]}
-                            className="inline-block w-5 h-5 mr-2"
-                          />
+                          {getAttributionImageSrc(block.attribution[0]) ? (
+                            <img
+                              src={getAttributionImageSrc(block.attribution[0]) || ''}
+                              alt={block.attribution[0]}
+                              className="inline-block w-5 h-5 mr-2"
+                            />
+                          ) : (
+                            <span className="inline-flex items-center justify-center w-5 h-5 rounded-full mr-2 bg-gray-500 text-[10px] text-white font-medium">
+                              {getAttributionInitial(block.attribution[0])}
+                            </span>
+                          )}
                           <span className="whitespace-nowrap">{block.attribution[0]}</span>
                         </div>
                       ) : (
                         <div className="flex items-center">
                           <div className="flex -space-x-2">
-                            {block.attribution.map((attr, idx) => (
-                              <img
-                                key={idx}
-                                src={`/images/${attr.toLowerCase()}.png`}
-                                alt={attr}
-                                className="inline-block w-5 h-5 rounded-full ring-1 ring-gray-800 min-w-[1.25rem] min-h-[1.25rem]"
-                                title={attr}
-                              />
-                            ))}
+                            {block.attribution.map((attr, idx) => {
+                              const imageSrc = getAttributionImageSrc(attr);
+
+                              return imageSrc ? (
+                                <img
+                                  key={idx}
+                                  src={imageSrc}
+                                  alt={attr}
+                                  className="inline-block w-5 h-5 rounded-full ring-1 ring-gray-800 min-w-[1.25rem] min-h-[1.25rem]"
+                                  title={attr}
+                                />
+                              ) : (
+                                <span
+                                  key={idx}
+                                  className="inline-flex items-center justify-center w-5 h-5 rounded-full ring-1 ring-gray-800 min-w-[1.25rem] min-h-[1.25rem] bg-gray-500 text-[10px] text-white font-medium"
+                                  title={attr}
+                                >
+                                  {getAttributionInitial(attr)}
+                                </span>
+                              );
+                            })}
                           </div>
                           <span className="whitespace-nowrap text-sm text-white ml-6">
                             {block.attribution.length} networks

--- a/src/components/LiveMetrics.tsx
+++ b/src/components/LiveMetrics.tsx
@@ -13,7 +13,9 @@ export default function LiveMetrics() {
 
   // Fetch stats data from API
   const { data, isLoading, error } = useApiData<StatsResponse>(
-    () => api.getStats(selectedNetwork.apiParam)
+    () => api.getStats(selectedNetwork.apiParam),
+    undefined,
+    selectedNetwork.apiParam
   );
 
   // Transform API data into metrics format

--- a/src/components/MempoolTable.tsx
+++ b/src/components/MempoolTable.tsx
@@ -6,12 +6,15 @@ import { api } from '../lib/api';
 import { MempoolResponse, MempoolTransaction } from '../types';
 import DataStateWrapper from './DataStateWrapper';
 import { useNetwork } from '../hooks/useNetwork';
+import { getAttributionImageSrc, getAttributionInitial } from '../utils';
 
 export default function MempoolTable() {
   const { selectedNetwork } = useNetwork();
 
   const { data, isLoading, error } = useApiData<MempoolResponse>(
-    () => api.getMempool(10, selectedNetwork.apiParam)
+    () => api.getMempool(10, selectedNetwork.apiParam),
+    undefined,
+    selectedNetwork.apiParam
   );
 
   // Loading state for the table
@@ -95,11 +98,17 @@ export default function MempoolTable() {
                     <td className="py-3 px-6 text-sm text-white">
                       {tx.user ? (
                         <div className="flex items-center">
-                          <img
-                            src={`/images/${tx.user.toLowerCase()}.png`}
-                            alt={tx.user}
-                            className="inline-block w-5 h-5 mr-3"
-                          />
+                          {getAttributionImageSrc(tx.user) ? (
+                            <img
+                              src={getAttributionImageSrc(tx.user) || ''}
+                              alt={tx.user}
+                              className="inline-block w-5 h-5 mr-3"
+                            />
+                          ) : (
+                            <span className="inline-flex items-center justify-center w-5 h-5 rounded-full mr-3 bg-gray-500 text-[10px] text-white font-medium">
+                              {getAttributionInitial(tx.user)}
+                            </span>
+                          )}
                           {tx.user}
                         </div>
                       ) : (

--- a/src/components/TopUsersTable.tsx
+++ b/src/components/TopUsersTable.tsx
@@ -7,13 +7,16 @@ import { api } from '../lib/api';
 import { TopUsersResponse, User } from '../types';
 import DataStateWrapper from './DataStateWrapper';
 import { useNetwork } from '../hooks/useNetwork';
+import { getAttributionImageSrc, getAttributionInitial } from '../utils';
 
 export default function TopUsersTable() {
   const router = useRouter();
   const { selectedNetwork } = useNetwork();
 
   const { data, isLoading, error } = useApiData<TopUsersResponse>(
-    () => api.getTopUsers(10, selectedNetwork.apiParam)
+    () => api.getTopUsers(10, selectedNetwork.apiParam),
+    undefined,
+    selectedNetwork.apiParam
   );
 
   useEffect(() => {
@@ -215,14 +218,16 @@ export default function TopUsersTable() {
                   >
                     <td className="py-3 px-6 text-sm font-medium text-white whitespace-nowrap">
                       <div className="flex items-center">
-                        {user.name === 'Unknown' || user.name.includes('...') ? (
-                          <span className="inline-block w-5 h-5 rounded-full mr-3 bg-gray-500"></span>
-                        ) : (
+                        {getAttributionImageSrc(user.name) ? (
                           <img
-                            src={`/images/${user.name.toLowerCase()}.png`}
+                            src={getAttributionImageSrc(user.name) || ''}
                             alt={user.name}
                             className="inline-block w-5 h-5 mr-3"
                           />
+                        ) : (
+                          <span className="inline-flex items-center justify-center w-5 h-5 rounded-full mr-3 bg-gray-500 text-[10px] text-white font-medium">
+                            {getAttributionInitial(user.name)}
+                          </span>
                         )}
                         {user.name}
                       </div>

--- a/src/hooks/useApiData.test.ts
+++ b/src/hooks/useApiData.test.ts
@@ -37,6 +37,28 @@ describe('useApiData', () => {
 
     expect(fetchFn).toHaveBeenCalledTimes(2);
   });
+
+  it('does not refetch when an inline fetch callback is recreated without a key change', async () => {
+    const fetchFn = vi.fn().mockResolvedValue('ok');
+
+    const { rerender } = renderHook(
+      ({ refetchKey }) => useApiData(() => fetchFn(refetchKey), undefined, refetchKey),
+      { initialProps: { refetchKey: 'mainnet' } }
+    );
+
+    await waitFor(() => expect(fetchFn).toHaveBeenCalledTimes(1));
+
+    rerender({ refetchKey: 'mainnet' });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    rerender({ refetchKey: 'sepolia' });
+    await waitFor(() => expect(fetchFn).toHaveBeenCalledTimes(2));
+    expect(fetchFn).toHaveBeenLastCalledWith('sepolia');
+  });
 });
 
 describe('usePaginatedApiData', () => {

--- a/src/hooks/useApiData.ts
+++ b/src/hooks/useApiData.ts
@@ -1,27 +1,34 @@
 "use client";
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 
 /**
  * Generic hook for fetching data from API with loading and error states
  *
  * @param fetchFunction - Function that returns a promise with data
  * @param initialData - Optional initial data
+ * @param refetchKey - Optional key that triggers automatic refetch when changed
  */
 export function useApiData<T>(
   fetchFunction: () => Promise<T>,
-  initialData?: T
+  initialData?: T,
+  refetchKey?: unknown
 ) {
   const [data, setData] = useState<T | undefined>(initialData);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<Error | null>(null);
+  const fetchFunctionRef = useRef(fetchFunction);
+
+  useEffect(() => {
+    fetchFunctionRef.current = fetchFunction;
+  }, [fetchFunction]);
 
   const refetch = useCallback(async () => {
     setIsLoading(true);
     setError(null);
 
     try {
-      const result = await fetchFunction();
+      const result = await fetchFunctionRef.current();
       setData(result);
       return result;
     } catch (err) {
@@ -31,11 +38,11 @@ export function useApiData<T>(
     } finally {
       setIsLoading(false);
     }
-  }, [fetchFunction]);
+  }, []);
 
   useEffect(() => {
     refetch();
-  }, [refetch]);
+  }, [refetch, refetchKey]);
 
   return { data, isLoading, error, refetch };
 }
@@ -59,7 +66,11 @@ export function usePaginatedApiData<T>(
   }, [fetchFunction, page, limit, network]);
 
   // Use the base hook
-  const { data, isLoading, error, refetch } = useApiData<T>(fetchData);
+  const { data, isLoading, error, refetch } = useApiData<T>(
+    fetchData,
+    undefined,
+    `${network || ''}:${page}:${limit}`
+  );
 
   // Navigation functions
   const nextPage = useCallback(() => {

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -30,7 +30,9 @@ export function useChartData() {
     error: blobsError,
     refetch: refetchBlobs,
   } = useApiData<BlobResponse[]>(
-    () => api.getRawBlobs(limit, selectedNetwork.apiParam)
+    () => api.getRawBlobs(limit, selectedNetwork.apiParam),
+    undefined,
+    `${selectedNetwork.apiParam}:${limit}`
   );
 
   const {
@@ -38,7 +40,9 @@ export function useChartData() {
     isLoading: statsLoading,
     error: statsError,
   } = useApiData<StatsResponse>(
-    () => api.getStats(selectedNetwork.apiParam)
+    () => api.getStats(selectedNetwork.apiParam),
+    undefined,
+    selectedNetwork.apiParam
   );
 
   const chartData: ChartDataset | null = useMemo(() => {

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,4 +1,11 @@
-import { formatDate, formatNumber, formatWeiToReadable, truncateAddress } from './index';
+import {
+  formatDate,
+  formatNumber,
+  formatWeiToReadable,
+  getAttributionImageSrc,
+  getAttributionInitial,
+  truncateAddress,
+} from './index';
 
 describe('utils', () => {
   it('formats numbers with locale separators', () => {
@@ -19,5 +26,13 @@ describe('utils', () => {
     expect(formatWeiToReadable('500')).toBe('500 Wei');
     expect(formatWeiToReadable('1000000000')).toContain('Gwei');
     expect(formatWeiToReadable('1000000000000000000')).toContain('ETH');
+    expect(formatWeiToReadable('4878649006.97818347')).toBe('4.878649006 Gwei');
+  });
+
+  it('maps known attribution names to local images', () => {
+    expect(getAttributionImageSrc('OP Mainnet')).toBe('/images/optimism.png');
+    expect(getAttributionImageSrc('Arbitrum One')).toBe('/images/arbitrum.png');
+    expect(getAttributionImageSrc('Taiko')).toBeNull();
+    expect(getAttributionInitial('Taiko')).toBe('T');
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,6 +3,16 @@
  */
 import { formatUnits } from 'viem';
 
+const ATTRIBUTION_IMAGE_NAMES: Record<string, string> = {
+  arbitrum: 'arbitrum',
+  'arbitrum one': 'arbitrum',
+  base: 'base',
+  optimism: 'optimism',
+  'op mainnet': 'optimism',
+  zksync: 'zksync',
+  'zksync era': 'zksync',
+};
+
 export function formatNumber(num: number): string {
   return new Intl.NumberFormat().format(num);
 }
@@ -10,6 +20,15 @@ export function formatNumber(num: number): string {
 export function truncateAddress(address: string, length: number = 6): string {
   if (!address) return '';
   return `${address.substring(0, length)}...${address.substring(address.length - 4)}`;
+}
+
+export function getAttributionImageSrc(name: string): string | null {
+  const imageName = ATTRIBUTION_IMAGE_NAMES[name.trim().toLowerCase()];
+  return imageName ? `/images/${imageName}.png` : null;
+}
+
+export function getAttributionInitial(name: string): string {
+  return name.trim().charAt(0).toUpperCase() || '?';
 }
 
 export function formatDate(date: Date): string {
@@ -27,8 +46,8 @@ export function formatDate(date: Date): string {
  * @returns Formatted string with appropriate unit
  */
 export function formatWeiToReadable(weiValue: string | number): string {
-  // Convert string to bigint if needed
-  const wei = typeof weiValue === 'string' ? BigInt(weiValue) : BigInt(weiValue.toString());
+  const integerWeiValue = weiValue.toString().split('.')[0] || '0';
+  const wei = BigInt(integerWeiValue);
 
   // Define thresholds for different units
   const GWEI_THRESHOLD = BigInt(1_000_000_000); // 10^9


### PR DESCRIPTION
## Summary

- Stop `useApiData` from automatically refetching whenever callers recreate inline fetch callbacks during render.
- Add explicit refetch keys for network, address, pagination, and chart-range driven data changes.
- Handle decimal wei strings returned by the live stats API without throwing.
- Avoid repeated local image 404s by mapping known attribution names to existing assets and rendering fallback initials for unknown attribution names.

## Root Cause

After CORS was fixed, the frontend began reaching the live API directly. Several components passed fresh inline functions into `useApiData`; each successful fetch updated state, triggered a render, created a new function identity, and retriggered the effect. Live stats also exposed decimal numeric strings that the formatter attempted to pass to `BigInt` unchanged.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint` (passes with existing `<img>` warnings)
- Verified locally against `NEXT_PUBLIC_API_URL=https://blob-indexer.ahkc.win/api/v1 npm run dev`: live metrics/data trends render without browser errors and the repeated request/image 404 flood is gone.
