### PR TITLE
feat: add blob pricing and pressure panels

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import Header from '@/components/Header';
 import LiveMetrics from '@/components/LiveMetrics';
+import BlobMarketPanels from '@/components/BlobMarketPanels';
 import MetricsCharts from '@/components/MetricsCharts';
 import LatestBlocksTable from '@/components/LatestBlocksTable';
 import TopUsersTable from '@/components/TopUsersTable';
@@ -20,6 +21,10 @@ export default function Home() {
         {/* Full width LiveMetrics with 4 cards */}
         <div className="mb-12">
           <LiveMetrics />
+        </div>
+
+        <div className="mb-12">
+          <BlobMarketPanels />
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-5 gap-12">

--- a/src/components/BlobMarketPanels.tsx
+++ b/src/components/BlobMarketPanels.tsx
@@ -1,44 +1,45 @@
 "use client";
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { API_BASE_URL } from '@/constants';
+import { useBlobWebSocket, useLiveBlobEvent } from '@/contexts/LiveDataContext';
 import { useNetwork } from '@/hooks/useNetwork';
 import { api } from '@/lib/api';
-import { BlobPricing, MempoolPressure } from '@/types';
+import { BlobPricing, BlobWebSocketConnectionState, MempoolPressure } from '@/types';
 import { formatNumber, formatPercent } from '@/utils';
 import DataStateWrapper from './DataStateWrapper';
 
 const FALLBACK_REFRESH_MS = 60000;
 const STALE_AFTER_MS = 90000;
 
-type RealtimeStatus = 'connecting' | 'connected' | 'disconnected';
-
 interface MarketSnapshot {
   pricing: BlobPricing;
   pressure: MempoolPressure;
 }
 
-interface NewBlockMessage {
-  type: 'new_block';
-}
-
 export default function BlobMarketPanels() {
   const { selectedNetwork } = useNetwork();
+  const { connectionState } = useBlobWebSocket();
   const [snapshot, setSnapshot] = useState<MarketSnapshot | undefined>();
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<Error | null>(null);
-  const [realtimeStatus, setRealtimeStatus] = useState<RealtimeStatus>('connecting');
   const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
   const [now, setNow] = useState(Date.now());
 
   const isMountedRef = useRef(false);
+  const inFlightNetworkRef = useRef<string | null>(null);
   const snapshotRef = useRef<MarketSnapshot | undefined>(undefined);
   const requestIdRef = useRef(0);
 
   const fetchMarketData = useCallback(async () => {
+    const network = selectedNetwork.apiParam;
+    if (inFlightNetworkRef.current === network) {
+      return;
+    }
+
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
+    inFlightNetworkRef.current = network;
     const hasSnapshot = Boolean(snapshotRef.current);
 
     if (hasSnapshot) {
@@ -49,8 +50,8 @@ export default function BlobMarketPanels() {
 
     try {
       const [pricing, pressure] = await Promise.all([
-        api.getBlobPricing(selectedNetwork.apiParam, 20),
-        api.getMempoolPressure(selectedNetwork.apiParam),
+        api.getBlobPricing(network, 20),
+        api.getMempoolPressure(network),
       ]);
 
       if (!isMountedRef.current || requestId !== requestIdRef.current) {
@@ -70,6 +71,7 @@ export default function BlobMarketPanels() {
       setError(err instanceof Error ? err : new Error('Unable to load market data'));
     } finally {
       if (isMountedRef.current && requestId === requestIdRef.current) {
+        inFlightNetworkRef.current = null;
         setIsLoading(false);
         setIsRefreshing(false);
       }
@@ -78,6 +80,7 @@ export default function BlobMarketPanels() {
 
   useEffect(() => {
     isMountedRef.current = true;
+    inFlightNetworkRef.current = null;
     snapshotRef.current = undefined;
     setSnapshot(undefined);
     setError(null);
@@ -90,57 +93,19 @@ export default function BlobMarketPanels() {
     };
   }, [fetchMarketData]);
 
+  useLiveBlobEvent('new_block', () => {
+    void fetchMarketData();
+  });
+
   useEffect(() => {
-    let isClosed = false;
-    let socket: WebSocket | null = null;
-    setRealtimeStatus('connecting');
-
-    try {
-      socket = new WebSocket(getMarketWebSocketUrl(selectedNetwork.apiParam));
-      socket.addEventListener('open', () => {
-        if (!isClosed) {
-          setRealtimeStatus('connected');
-        }
-      });
-      socket.addEventListener('message', (event: MessageEvent) => {
-        if (isClosed || typeof event.data !== 'string') {
-          return;
-        }
-
-        try {
-          const message: unknown = JSON.parse(event.data);
-          if (isNewBlockMessage(message)) {
-            setRealtimeStatus('connected');
-            void fetchMarketData();
-          }
-        } catch {
-          // Ignore malformed realtime messages; interval refresh is still active.
-        }
-      });
-      socket.addEventListener('error', () => {
-        if (!isClosed) {
-          setRealtimeStatus('disconnected');
-        }
-      });
-      socket.addEventListener('close', () => {
-        if (!isClosed) {
-          setRealtimeStatus('disconnected');
-        }
-      });
-    } catch {
-      setRealtimeStatus('disconnected');
-    }
-
     const fallbackTimer = window.setInterval(() => {
       void fetchMarketData();
     }, FALLBACK_REFRESH_MS);
 
     return () => {
-      isClosed = true;
       window.clearInterval(fallbackTimer);
-      socket?.close();
     };
-  }, [fetchMarketData, selectedNetwork.apiParam]);
+  }, [fetchMarketData]);
 
   useEffect(() => {
     const staleTimer = window.setInterval(() => {
@@ -152,7 +117,7 @@ export default function BlobMarketPanels() {
     };
   }, []);
 
-  const isStale = lastUpdatedAt !== null && now - lastUpdatedAt > STALE_AFTER_MS;
+  const isStale = connectionState === 'stale' || (lastUpdatedAt !== null && now - lastUpdatedAt > STALE_AFTER_MS);
   const initialError = snapshot ? null : error;
 
   return (
@@ -160,7 +125,7 @@ export default function BlobMarketPanels() {
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
         <h2 className="text-2xl font-windsor-bold text-white">Blob Market</h2>
         <div className="flex flex-wrap items-center gap-3 text-xs text-[#8f9aad]">
-          <MarketStatusPill status={realtimeStatus} isStale={isStale} />
+          <MarketStatusPill status={connectionState} isStale={isStale} />
           {isRefreshing && <span className="text-blue">Refreshing</span>}
           <span>{lastUpdatedAt ? `Updated ${formatUpdatedAt(lastUpdatedAt)}` : 'Waiting for data'}</span>
         </div>
@@ -360,7 +325,7 @@ function InclusionBar({
   );
 }
 
-function MarketStatusPill({ status, isStale }: { status: RealtimeStatus; isStale: boolean }) {
+function MarketStatusPill({ status, isStale }: { status: BlobWebSocketConnectionState; isStale: boolean }) {
   const config = getStatusConfig(status, isStale);
 
   return (
@@ -388,26 +353,8 @@ function BlobMarketSkeleton() {
   );
 }
 
-function getMarketWebSocketUrl(network: string): string {
-  const origin = typeof window === 'undefined' ? 'http://localhost' : window.location.origin;
-  const url = new URL(API_BASE_URL, origin);
-  url.pathname = `${url.pathname.replace(/\/$/, '')}/ws`;
-  url.search = '';
-  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
-  url.searchParams.set('network', network);
-  return url.toString();
-}
-
-function isNewBlockMessage(value: unknown): value is NewBlockMessage {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-
-  return (value as { type?: unknown }).type === 'new_block';
-}
-
-function getStatusConfig(status: RealtimeStatus, isStale: boolean) {
-  if (isStale) {
+function getStatusConfig(status: BlobWebSocketConnectionState, isStale: boolean) {
+  if (isStale || status === 'stale') {
     return {
       label: 'Stale',
       className: 'border-amber-300/40 bg-amber-300/10 text-amber-200',
@@ -420,6 +367,14 @@ function getStatusConfig(status: RealtimeStatus, isStale: boolean) {
       label: 'Live',
       className: 'border-green-400/40 bg-green-400/10 text-green-300',
       dotClassName: 'bg-green-400',
+    };
+  }
+
+  if (status === 'reconnecting') {
+    return {
+      label: 'Reconnecting',
+      className: 'border-blue/40 bg-blue/10 text-blue',
+      dotClassName: 'bg-blue',
     };
   }
 

--- a/src/components/BlobMarketPanels.tsx
+++ b/src/components/BlobMarketPanels.tsx
@@ -1,0 +1,459 @@
+"use client";
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { API_BASE_URL } from '@/constants';
+import { useNetwork } from '@/hooks/useNetwork';
+import { api } from '@/lib/api';
+import { BlobPricing, MempoolPressure } from '@/types';
+import { formatNumber, formatPercent } from '@/utils';
+import DataStateWrapper from './DataStateWrapper';
+
+const FALLBACK_REFRESH_MS = 60000;
+const STALE_AFTER_MS = 90000;
+
+type RealtimeStatus = 'connecting' | 'connected' | 'disconnected';
+
+interface MarketSnapshot {
+  pricing: BlobPricing;
+  pressure: MempoolPressure;
+}
+
+interface NewBlockMessage {
+  type: 'new_block';
+}
+
+export default function BlobMarketPanels() {
+  const { selectedNetwork } = useNetwork();
+  const [snapshot, setSnapshot] = useState<MarketSnapshot | undefined>();
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [realtimeStatus, setRealtimeStatus] = useState<RealtimeStatus>('connecting');
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
+  const [now, setNow] = useState(Date.now());
+
+  const isMountedRef = useRef(false);
+  const snapshotRef = useRef<MarketSnapshot | undefined>(undefined);
+  const requestIdRef = useRef(0);
+
+  const fetchMarketData = useCallback(async () => {
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    const hasSnapshot = Boolean(snapshotRef.current);
+
+    if (hasSnapshot) {
+      setIsRefreshing(true);
+    } else {
+      setIsLoading(true);
+    }
+
+    try {
+      const [pricing, pressure] = await Promise.all([
+        api.getBlobPricing(selectedNetwork.apiParam, 20),
+        api.getMempoolPressure(selectedNetwork.apiParam),
+      ]);
+
+      if (!isMountedRef.current || requestId !== requestIdRef.current) {
+        return;
+      }
+
+      const nextSnapshot = { pricing, pressure };
+      snapshotRef.current = nextSnapshot;
+      setSnapshot(nextSnapshot);
+      setLastUpdatedAt(Date.now());
+      setError(null);
+    } catch (err) {
+      if (!isMountedRef.current || requestId !== requestIdRef.current) {
+        return;
+      }
+
+      setError(err instanceof Error ? err : new Error('Unable to load market data'));
+    } finally {
+      if (isMountedRef.current && requestId === requestIdRef.current) {
+        setIsLoading(false);
+        setIsRefreshing(false);
+      }
+    }
+  }, [selectedNetwork.apiParam]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    snapshotRef.current = undefined;
+    setSnapshot(undefined);
+    setError(null);
+    setLastUpdatedAt(null);
+    setIsLoading(true);
+    void fetchMarketData();
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, [fetchMarketData]);
+
+  useEffect(() => {
+    let isClosed = false;
+    let socket: WebSocket | null = null;
+    setRealtimeStatus('connecting');
+
+    try {
+      socket = new WebSocket(getMarketWebSocketUrl(selectedNetwork.apiParam));
+      socket.addEventListener('open', () => {
+        if (!isClosed) {
+          setRealtimeStatus('connected');
+        }
+      });
+      socket.addEventListener('message', (event: MessageEvent) => {
+        if (isClosed || typeof event.data !== 'string') {
+          return;
+        }
+
+        try {
+          const message: unknown = JSON.parse(event.data);
+          if (isNewBlockMessage(message)) {
+            setRealtimeStatus('connected');
+            void fetchMarketData();
+          }
+        } catch {
+          // Ignore malformed realtime messages; interval refresh is still active.
+        }
+      });
+      socket.addEventListener('error', () => {
+        if (!isClosed) {
+          setRealtimeStatus('disconnected');
+        }
+      });
+      socket.addEventListener('close', () => {
+        if (!isClosed) {
+          setRealtimeStatus('disconnected');
+        }
+      });
+    } catch {
+      setRealtimeStatus('disconnected');
+    }
+
+    const fallbackTimer = window.setInterval(() => {
+      void fetchMarketData();
+    }, FALLBACK_REFRESH_MS);
+
+    return () => {
+      isClosed = true;
+      window.clearInterval(fallbackTimer);
+      socket?.close();
+    };
+  }, [fetchMarketData, selectedNetwork.apiParam]);
+
+  useEffect(() => {
+    const staleTimer = window.setInterval(() => {
+      setNow(Date.now());
+    }, 15000);
+
+    return () => {
+      window.clearInterval(staleTimer);
+    };
+  }, []);
+
+  const isStale = lastUpdatedAt !== null && now - lastUpdatedAt > STALE_AFTER_MS;
+  const initialError = snapshot ? null : error;
+
+  return (
+    <section>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        <h2 className="text-2xl font-windsor-bold text-white">Blob Market</h2>
+        <div className="flex flex-wrap items-center gap-3 text-xs text-[#8f9aad]">
+          <MarketStatusPill status={realtimeStatus} isStale={isStale} />
+          {isRefreshing && <span className="text-blue">Refreshing</span>}
+          <span>{lastUpdatedAt ? `Updated ${formatUpdatedAt(lastUpdatedAt)}` : 'Waiting for data'}</span>
+        </div>
+      </div>
+
+      <DataStateWrapper
+        isLoading={isLoading && !snapshot}
+        error={initialError}
+        loadingComponent={<BlobMarketSkeleton />}
+      >
+        {snapshot && (
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+            <PricingPanel pricing={snapshot.pricing} />
+            <PressurePanel pressure={snapshot.pressure} />
+          </div>
+        )}
+      </DataStateWrapper>
+
+      {snapshot && error && (
+        <p className="mt-3 text-xs text-red-300">
+          Refresh failed: {error.message}. Showing the latest available market data.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function PricingPanel({ pricing }: { pricing: BlobPricing }) {
+  const direction = pricing.marketPressure.predictedDirection.toLowerCase();
+  const directionClass = getDirectionClass(direction);
+  const utilizationPercent = formatPercent(pricing.currentUtilization * 100);
+
+  return (
+    <article className="rounded-lg border border-divider bg-[#161a29]/80 p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-lg font-medium text-white">Blob Pricing</h3>
+          <p className="text-sm text-[#8f9aad]">{pricing.forkStage} fork parameters</p>
+        </div>
+        <span className={`rounded-full border px-3 py-1 text-xs capitalize ${directionClass}`}>
+          {direction || 'stable'}
+        </span>
+      </div>
+
+      <div className="mt-5 grid grid-cols-1 sm:grid-cols-2 gap-5">
+        <MetricBlock label="Current base fee" value={pricing.currentBaseFee} />
+        <MetricBlock label="Predicted next fee" value={pricing.predictedNextFee} />
+      </div>
+
+      <div className="mt-5 border-t border-divider pt-5">
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          <MetricBlock
+            label="Next-block range"
+            value={`${pricing.marketPressure.nextBlockFeeEstimate.low} - ${pricing.marketPressure.nextBlockFeeEstimate.high}`}
+            compact
+          />
+          <MetricBlock label="Current utilization" value={utilizationPercent} compact />
+          <MetricBlock
+            label="Target / max blobs"
+            value={`${pricing.blobParams.target.toLocaleString()} / ${pricing.blobParams.max.toLocaleString()}`}
+            compact
+          />
+          <MetricBlock
+            label="Excess blob gas"
+            value={formatNumber(pricing.currentExcessGas)}
+            compact
+          />
+        </div>
+      </div>
+
+      <div className="mt-5 grid grid-cols-3 gap-3 border-t border-divider pt-5">
+        <MiniStat label="Above target" value={pricing.marketPressure.recentBlocksAboveTarget.toString()} />
+        <MiniStat label="Full streak" value={pricing.marketPressure.consecutiveFullBlocks.toString()} />
+        <MiniStat
+          label="At max"
+          value={formatPercent(pricing.marketPressure.percentRecentBlocksAtMaxBlobs)}
+        />
+      </div>
+    </article>
+  );
+}
+
+function PressurePanel({ pressure }: { pressure: MempoolPressure }) {
+  const totalPending = pressure.pendingBlobCount;
+  const includability = pressure.includability;
+
+  return (
+    <article className="rounded-lg border border-divider bg-[#161a29]/80 p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-lg font-medium text-white">Inclusion Pressure</h3>
+          <p className="text-sm text-[#8f9aad]">
+            {includability.pricingAvailable ? `Base fee ${includability.latestBlobBaseFee}` : 'Pricing unavailable'}
+          </p>
+        </div>
+        <span className="rounded-full border border-blue/40 bg-blue/10 px-3 py-1 text-xs text-blue">
+          {totalPending.toLocaleString()} pending
+        </span>
+      </div>
+
+      <div className="mt-5 grid grid-cols-3 gap-3">
+        <MiniStat label="Blob gas" value={formatNumber(pressure.pendingBlobGas)} />
+        <MiniStat label="Senders" value={pressure.pendingUniqueSenders.toLocaleString()} />
+        <MiniStat label="Sample" value={pressure.sampleTruncated ? `${pressure.sampleLimit}+` : pressure.sampleLimit.toLocaleString()} />
+      </div>
+
+      <div className="mt-5 border-t border-divider pt-5 space-y-4">
+        <InclusionBar
+          label="Likely includable"
+          value={includability.likelyIncludableCount}
+          total={totalPending}
+          colorClass="bg-green-400"
+        />
+        <InclusionBar
+          label="Underpriced"
+          value={includability.underpricedCount}
+          total={totalPending}
+          colorClass="bg-amber-300"
+        />
+        <InclusionBar
+          label="Unknown pricing"
+          value={includability.unknownPricingCount}
+          total={totalPending}
+          colorClass="bg-[#8f9aad]"
+        />
+      </div>
+
+      <div className="mt-5 border-t border-divider pt-5">
+        <h4 className="text-sm font-medium text-white mb-3">Mempool fee distribution</h4>
+        <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
+          <MiniStat label="Min" value={pressure.feeDistribution.min} />
+          <MiniStat label="Median" value={pressure.feeDistribution.median} />
+          <MiniStat label="Avg" value={pressure.feeDistribution.avg} />
+          <MiniStat label="P95" value={pressure.feeDistribution.p95} />
+          <MiniStat label="Max" value={pressure.feeDistribution.max} />
+        </div>
+      </div>
+
+      <div className="mt-5 border-t border-divider pt-5">
+        <h4 className="text-sm font-medium text-white mb-3">Pending age</h4>
+        <div className="grid grid-cols-3 gap-3">
+          <MiniStat label="Newest" value={pressure.pendingTransactionAge.newest} />
+          <MiniStat label="Average" value={pressure.pendingTransactionAge.average} />
+          <MiniStat label="Oldest" value={pressure.pendingTransactionAge.oldest} />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function MetricBlock({ label, value, compact = false }: { label: string; value: string; compact?: boolean }) {
+  return (
+    <div>
+      <div className="text-xs uppercase text-[#8f9aad]">{label}</div>
+      <div className={`${compact ? 'text-base' : 'text-2xl'} mt-1 font-medium text-white break-words`}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function MiniStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-xs text-[#8f9aad]">{label}</div>
+      <div className="mt-1 text-sm font-medium text-white break-words">{value}</div>
+    </div>
+  );
+}
+
+function InclusionBar({
+  label,
+  value,
+  total,
+  colorClass,
+}: {
+  label: string;
+  value: number;
+  total: number;
+  colorClass: string;
+}) {
+  const percent = total > 0 ? (value / total) * 100 : 0;
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between gap-3 text-sm">
+        <span className="text-white">{label}</span>
+        <span className="text-[#8f9aad]">{value.toLocaleString()} / {total.toLocaleString()}</span>
+      </div>
+      <div className="h-2 overflow-hidden rounded-full bg-[#202538]">
+        <div
+          className={`h-full rounded-full ${colorClass}`}
+          style={{ width: `${Math.min(100, percent)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function MarketStatusPill({ status, isStale }: { status: RealtimeStatus; isStale: boolean }) {
+  const config = getStatusConfig(status, isStale);
+
+  return (
+    <span className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 ${config.className}`}>
+      <span className={`h-2 w-2 rounded-full ${config.dotClassName}`} />
+      {config.label}
+    </span>
+  );
+}
+
+function BlobMarketSkeleton() {
+  return (
+    <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+      {[...Array(2)].map((_, index) => (
+        <div key={index} className="animate-pulse rounded-lg border border-divider bg-[#161a29]/80 p-5">
+          <div className="h-6 w-1/3 rounded bg-[#202538] mb-5" />
+          <div className="grid grid-cols-2 gap-5">
+            <div className="h-20 rounded bg-[#202538]" />
+            <div className="h-20 rounded bg-[#202538]" />
+          </div>
+          <div className="mt-5 h-28 rounded bg-[#202538]" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function getMarketWebSocketUrl(network: string): string {
+  const origin = typeof window === 'undefined' ? 'http://localhost' : window.location.origin;
+  const url = new URL(API_BASE_URL, origin);
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/ws`;
+  url.search = '';
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.searchParams.set('network', network);
+  return url.toString();
+}
+
+function isNewBlockMessage(value: unknown): value is NewBlockMessage {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  return (value as { type?: unknown }).type === 'new_block';
+}
+
+function getStatusConfig(status: RealtimeStatus, isStale: boolean) {
+  if (isStale) {
+    return {
+      label: 'Stale',
+      className: 'border-amber-300/40 bg-amber-300/10 text-amber-200',
+      dotClassName: 'bg-amber-300',
+    };
+  }
+
+  if (status === 'connected') {
+    return {
+      label: 'Live',
+      className: 'border-green-400/40 bg-green-400/10 text-green-300',
+      dotClassName: 'bg-green-400',
+    };
+  }
+
+  if (status === 'connecting') {
+    return {
+      label: 'Connecting',
+      className: 'border-blue/40 bg-blue/10 text-blue',
+      dotClassName: 'bg-blue',
+    };
+  }
+
+  return {
+    label: 'Disconnected',
+    className: 'border-red-300/40 bg-red-300/10 text-red-200',
+    dotClassName: 'bg-red-300',
+  };
+}
+
+function getDirectionClass(direction: string): string {
+  if (direction === 'up') {
+    return 'border-red-300/40 bg-red-300/10 text-red-200';
+  }
+
+  if (direction === 'down') {
+    return 'border-green-400/40 bg-green-400/10 text-green-300';
+  }
+
+  return 'border-[#8f9aad]/40 bg-[#8f9aad]/10 text-[#d7dde8]';
+}
+
+function formatUpdatedAt(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}

--- a/src/lib/api/index.test.ts
+++ b/src/lib/api/index.test.ts
@@ -10,6 +10,8 @@ describe('api/index', () => {
     expect(api).toHaveProperty('getStats');
     expect(api).toHaveProperty('getStatus');
     expect(api).toHaveProperty('getMempool');
+    expect(api).toHaveProperty('getMempoolPressure');
+    expect(api).toHaveProperty('getBlobPricing');
     expect(api).toHaveProperty('getTopUsers');
     expect(api).toHaveProperty('getUserByAddress');
     expect(api).toHaveProperty('getUserBlobs');

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,6 +1,7 @@
 import { getLatestBlocks, getBlobByTxHash } from './blocks';
 import { getRawBlobs } from './blobs';
-import { getMempool } from './mempool';
+import { getMempool, getMempoolPressure } from './mempool';
+import { getBlobPricing } from './pricing';
 import { getStats } from './stats';
 import { getStatus } from './status';
 import { getTopUsers, getUserByAddress, getUserBlobs } from './users';
@@ -12,6 +13,8 @@ export const api = {
     getStats,
     getStatus,
     getMempool,
+    getMempoolPressure,
+    getBlobPricing,
     getTopUsers,
     getUserByAddress,
     getUserBlobs,

--- a/src/lib/api/mempool.test.ts
+++ b/src/lib/api/mempool.test.ts
@@ -1,4 +1,4 @@
-import { getMempool } from './mempool';
+import { getMempool, getMempoolPressure } from './mempool';
 
 const originalFetch = global.fetch;
 
@@ -50,5 +50,78 @@ describe('api/mempool', () => {
       timeInMempool: '5 min ago',
     });
     expect(result.data[0].estimatedCost).toContain('Gwei');
+  });
+
+  it('maps mempool pressure into includability and compact fee data', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          network_id: 1,
+          network_name: 'mainnet',
+          pending_blob_count: 4,
+          pending_blob_gas: 524288,
+          pending_unique_senders: 3,
+          max_fee_per_blob_gas: {
+            min: '8794420',
+            avg: '504839295.75000000',
+            median: '10562763',
+            p95: '1000000000',
+            max: '2000000000',
+          },
+          pending_tx_age: {
+            oldest_age_seconds: 695.7,
+            newest_age_seconds: 20.7,
+            average_age_seconds: 314.03,
+            oldest_timestamp: '2026-01-01T00:00:00Z',
+            newest_timestamp: '2026-01-01T00:10:00Z',
+          },
+          includability: {
+            latest_blob_base_fee: '9389122',
+            pricing_available: true,
+            likely_includable_count: 3,
+            underpriced_count: 1,
+            unknown_pricing_count: 0,
+          },
+          sample_limit: 10000,
+          sample_truncated: false,
+          generated_at: '2026-01-01T00:11:00Z',
+        },
+      }),
+    });
+
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await getMempoolPressure('mainnet');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/blob/mempool/pressure?network=mainnet'),
+      expect.any(Object)
+    );
+    expect(result).toMatchObject({
+      pendingBlobCount: 4,
+      pendingBlobGas: 524288,
+      pendingUniqueSenders: 3,
+      feeDistribution: {
+        min: '0.008794 Gwei',
+        avg: '0.504839 Gwei',
+        median: '0.010563 Gwei',
+        p95: '1 Gwei',
+        max: '2 Gwei',
+      },
+      pendingTransactionAge: {
+        oldest: '12 min',
+        newest: '21 sec',
+        average: '5 min',
+      },
+      includability: {
+        latestBlobBaseFee: '0.009389 Gwei',
+        pricingAvailable: true,
+        likelyIncludableCount: 3,
+        underpricedCount: 1,
+        unknownPricingCount: 0,
+      },
+    });
   });
 });

--- a/src/lib/api/mempool.ts
+++ b/src/lib/api/mempool.ts
@@ -1,6 +1,13 @@
-import { MempoolResponse, MempoolTransaction, ApiResponse, BlobResponse } from '../../types';
+import {
+    ApiResponse,
+    BackendMempoolPressureResponse,
+    BlobResponse,
+    MempoolPressure,
+    MempoolResponse,
+    MempoolTransaction
+} from '../../types';
 import { fetchApi, formatRelativeTime, truncateAddress } from './core';
-import { formatWeiToReadable } from '../../utils';
+import { formatDuration, formatWeiToGwei, formatWeiToReadable } from '../../utils';
 
 /**
  * Get mempool data (pending blob transactions)
@@ -24,4 +31,52 @@ export async function getMempool(limit = 10, network?: string): Promise<MempoolR
     });
 
     return { data: transactions };
+}
+
+/**
+ * Get current mempool inclusion pressure for pending blob transactions.
+ * @param network - Optional network parameter
+ */
+export async function getMempoolPressure(network?: string): Promise<MempoolPressure> {
+    const response = await fetchApi<ApiResponse<BackendMempoolPressureResponse>>(
+        '/blob/mempool/pressure',
+        network
+    );
+
+    const pressure = response.data;
+
+    return {
+        networkId: pressure.network_id,
+        networkName: pressure.network_name,
+        pendingBlobCount: pressure.pending_blob_count,
+        pendingBlobGas: pressure.pending_blob_gas,
+        pendingUniqueSenders: pressure.pending_unique_senders,
+        feeDistribution: {
+            min: formatWeiToGwei(pressure.max_fee_per_blob_gas.min),
+            avg: formatWeiToGwei(pressure.max_fee_per_blob_gas.avg),
+            median: formatWeiToGwei(pressure.max_fee_per_blob_gas.median),
+            p95: formatWeiToGwei(pressure.max_fee_per_blob_gas.p95),
+            max: formatWeiToGwei(pressure.max_fee_per_blob_gas.max),
+        },
+        pendingTransactionAge: {
+            oldest: formatDuration(pressure.pending_tx_age.oldest_age_seconds),
+            newest: formatDuration(pressure.pending_tx_age.newest_age_seconds),
+            average: formatDuration(pressure.pending_tx_age.average_age_seconds),
+            oldestSeconds: pressure.pending_tx_age.oldest_age_seconds,
+            newestSeconds: pressure.pending_tx_age.newest_age_seconds,
+            averageSeconds: pressure.pending_tx_age.average_age_seconds,
+            oldestTimestamp: pressure.pending_tx_age.oldest_timestamp,
+            newestTimestamp: pressure.pending_tx_age.newest_timestamp,
+        },
+        includability: {
+            latestBlobBaseFee: formatWeiToGwei(pressure.includability.latest_blob_base_fee),
+            pricingAvailable: pressure.includability.pricing_available,
+            likelyIncludableCount: pressure.includability.likely_includable_count,
+            underpricedCount: pressure.includability.underpriced_count,
+            unknownPricingCount: pressure.includability.unknown_pricing_count,
+        },
+        sampleLimit: pressure.sample_limit,
+        sampleTruncated: pressure.sample_truncated,
+        generatedAt: pressure.generated_at,
+    };
 }

--- a/src/lib/api/pricing.test.ts
+++ b/src/lib/api/pricing.test.ts
@@ -1,0 +1,113 @@
+import { getBlobPricing } from './pricing';
+
+const originalFetch = global.fetch;
+
+describe('api/pricing', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('maps blob pricing and fork params for display', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          network_id: 1,
+          network_name: 'mainnet',
+          current_base_fee: '9389122',
+          current_base_fee_gwei: '0.009389122',
+          current_excess_gas: 187598122,
+          current_utilization: '0.357143',
+          predicted_next_fee: '8487503',
+          predicted_next_fee_gwei: '0.008487503',
+          fork_stage: 'BPO2',
+          blob_params: {
+            target: 14,
+            max: 21,
+            update_fraction: 11684671,
+            target_gas: 1835008,
+            max_gas: 2752512,
+          },
+          market_pressure: {
+            recent_blocks_above_target: 2,
+            consecutive_full_blocks: 1,
+            percent_recent_blocks_at_max_blobs: 10,
+            predicted_direction: 'down',
+            next_block_fee_estimate: {
+              low: '6935695',
+              high: '8487503',
+            },
+          },
+          recent_blocks: [
+            {
+              block_number: 100,
+              block_timestamp: '2026-01-01T00:00:00Z',
+              blob_count: 4,
+              blob_gas_used: 1310720,
+              blob_gas_target: 1835008,
+              blob_gas_limit: 2752512,
+              excess_blob_gas: 187598122,
+              blob_base_fee: '9389122',
+              blob_base_fee_gwei: '0.009389122',
+              utilization_ratio: '0.714286',
+              blob_params_target: 14,
+              blob_params_max: 21,
+              target_blobs: 14,
+              max_blobs: 21,
+              available_blobs: 17,
+              utilization_percent: 19.05,
+              is_full: false,
+              is_above_target: false,
+              update_fraction: 11684671,
+            },
+          ],
+        },
+      }),
+    });
+
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await getBlobPricing('mainnet', 20);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/blob/pricing?blocks=20&network=mainnet'),
+      expect.any(Object)
+    );
+    expect(result).toMatchObject({
+      networkName: 'mainnet',
+      currentBaseFee: '0.009389 Gwei',
+      predictedNextFee: '0.008488 Gwei',
+      currentExcessGas: 187598122,
+      currentUtilization: 0.357143,
+      forkStage: 'BPO2',
+      blobParams: {
+        target: 14,
+        max: 21,
+        targetGas: 1835008,
+        maxGas: 2752512,
+      },
+      marketPressure: {
+        recentBlocksAboveTarget: 2,
+        consecutiveFullBlocks: 1,
+        predictedDirection: 'down',
+        nextBlockFeeEstimate: {
+          low: '0.006936 Gwei',
+          high: '0.008488 Gwei',
+        },
+      },
+    });
+    expect(result.recentBlocks[0]).toMatchObject({
+      blockNumber: 100,
+      blobCount: 4,
+      blobBaseFee: '0.009389 Gwei',
+      utilizationRatio: 0.714286,
+      targetBlobs: 14,
+      maxBlobs: 21,
+    });
+  });
+});

--- a/src/lib/api/pricing.ts
+++ b/src/lib/api/pricing.ts
@@ -1,0 +1,76 @@
+import {
+    ApiResponse,
+    BackendBlobPricingRecentBlock,
+    BackendBlobPricingResponse,
+    BlobPricing,
+    BlobPricingRecentBlock
+} from '../../types';
+import { formatGwei, formatWeiToGwei } from '../../utils';
+import { fetchApi } from './core';
+
+/**
+ * Get current blob fee pricing and recent market pressure.
+ * @param network - Optional network parameter
+ * @param blocks - Number of recent blocks to include
+ */
+export async function getBlobPricing(network?: string, blocks = 20): Promise<BlobPricing> {
+    const response = await fetchApi<ApiResponse<BackendBlobPricingResponse>>(
+        `/blob/pricing?blocks=${blocks}`,
+        network
+    );
+
+    return mapBlobPricing(response.data);
+}
+
+function mapBlobPricing(pricing: BackendBlobPricingResponse): BlobPricing {
+    return {
+        networkId: pricing.network_id,
+        networkName: pricing.network_name,
+        currentBaseFee: formatGwei(pricing.current_base_fee_gwei),
+        currentBaseFeeGwei: pricing.current_base_fee_gwei,
+        currentExcessGas: pricing.current_excess_gas,
+        currentUtilization: Number(pricing.current_utilization),
+        predictedNextFee: formatGwei(pricing.predicted_next_fee_gwei),
+        predictedNextFeeGwei: pricing.predicted_next_fee_gwei,
+        forkStage: pricing.fork_stage,
+        blobParams: {
+            target: pricing.blob_params.target,
+            max: pricing.blob_params.max,
+            updateFraction: pricing.blob_params.update_fraction,
+            targetGas: pricing.blob_params.target_gas,
+            maxGas: pricing.blob_params.max_gas,
+        },
+        marketPressure: {
+            recentBlocksAboveTarget: pricing.market_pressure.recent_blocks_above_target,
+            consecutiveFullBlocks: pricing.market_pressure.consecutive_full_blocks,
+            percentRecentBlocksAtMaxBlobs: pricing.market_pressure.percent_recent_blocks_at_max_blobs,
+            predictedDirection: pricing.market_pressure.predicted_direction,
+            nextBlockFeeEstimate: {
+                low: formatWeiToGwei(pricing.market_pressure.next_block_fee_estimate.low),
+                high: formatWeiToGwei(pricing.market_pressure.next_block_fee_estimate.high),
+            },
+        },
+        recentBlocks: pricing.recent_blocks.map(mapRecentBlock),
+    };
+}
+
+function mapRecentBlock(block: BackendBlobPricingRecentBlock): BlobPricingRecentBlock {
+    return {
+        blockNumber: block.block_number,
+        blockTimestamp: block.block_timestamp,
+        blobCount: block.blob_count,
+        blobGasUsed: block.blob_gas_used,
+        blobGasTarget: block.blob_gas_target,
+        blobGasLimit: block.blob_gas_limit,
+        excessBlobGas: block.excess_blob_gas,
+        blobBaseFee: formatGwei(block.blob_base_fee_gwei),
+        blobBaseFeeGwei: block.blob_base_fee_gwei,
+        utilizationRatio: Number(block.utilization_ratio),
+        targetBlobs: block.target_blobs,
+        maxBlobs: block.max_blobs,
+        availableBlobs: block.available_blobs,
+        utilizationPercent: block.utilization_percent,
+        isFull: block.is_full,
+        isAboveTarget: block.is_above_target,
+    };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,6 +63,196 @@ export interface MempoolResponse {
   data: MempoolTransaction[];
 }
 
+export interface BackendFeeDistribution {
+  min: string;
+  avg: string;
+  median: string;
+  p95: string;
+  max: string;
+}
+
+export interface BackendPendingTransactionAge {
+  oldest_age_seconds: number;
+  newest_age_seconds: number;
+  average_age_seconds: number;
+  oldest_timestamp: string;
+  newest_timestamp: string;
+}
+
+export interface BackendMempoolIncludability {
+  latest_blob_base_fee: string;
+  pricing_available: boolean;
+  likely_includable_count: number;
+  underpriced_count: number;
+  unknown_pricing_count: number;
+}
+
+export interface BackendMempoolPressureResponse {
+  network_id: number;
+  network_name: string;
+  pending_blob_count: number;
+  pending_blob_gas: number;
+  pending_unique_senders: number;
+  max_fee_per_blob_gas: BackendFeeDistribution;
+  pending_tx_age: BackendPendingTransactionAge;
+  includability: BackendMempoolIncludability;
+  sample_limit: number;
+  sample_truncated: boolean;
+  generated_at: string;
+}
+
+export interface FeeDistribution {
+  min: string;
+  avg: string;
+  median: string;
+  p95: string;
+  max: string;
+}
+
+export interface PendingTransactionAge {
+  oldest: string;
+  newest: string;
+  average: string;
+  oldestSeconds: number;
+  newestSeconds: number;
+  averageSeconds: number;
+  oldestTimestamp: string;
+  newestTimestamp: string;
+}
+
+export interface MempoolIncludability {
+  latestBlobBaseFee: string;
+  pricingAvailable: boolean;
+  likelyIncludableCount: number;
+  underpricedCount: number;
+  unknownPricingCount: number;
+}
+
+export interface MempoolPressure {
+  networkId: number;
+  networkName: string;
+  pendingBlobCount: number;
+  pendingBlobGas: number;
+  pendingUniqueSenders: number;
+  feeDistribution: FeeDistribution;
+  pendingTransactionAge: PendingTransactionAge;
+  includability: MempoolIncludability;
+  sampleLimit: number;
+  sampleTruncated: boolean;
+  generatedAt: string;
+}
+
+export interface BlobPricingParams {
+  target: number;
+  max: number;
+  updateFraction: number;
+  targetGas: number;
+  maxGas: number;
+}
+
+export interface BackendBlobPricingParams {
+  target: number;
+  max: number;
+  update_fraction: number;
+  target_gas: number;
+  max_gas: number;
+}
+
+export interface BackendNextBlockFeeEstimate {
+  low: string;
+  high: string;
+}
+
+export interface BackendBlobMarketPressure {
+  recent_blocks_above_target: number;
+  consecutive_full_blocks: number;
+  percent_recent_blocks_at_max_blobs: number;
+  predicted_direction: string;
+  next_block_fee_estimate: BackendNextBlockFeeEstimate;
+}
+
+export interface BlobMarketPressure {
+  recentBlocksAboveTarget: number;
+  consecutiveFullBlocks: number;
+  percentRecentBlocksAtMaxBlobs: number;
+  predictedDirection: string;
+  nextBlockFeeEstimate: {
+    low: string;
+    high: string;
+  };
+}
+
+export interface BackendBlobPricingRecentBlock {
+  block_number: number;
+  block_timestamp: string;
+  blob_count: number;
+  blob_gas_used: number;
+  blob_gas_target: number;
+  blob_gas_limit: number;
+  excess_blob_gas: number;
+  blob_base_fee: string;
+  blob_base_fee_gwei: string;
+  utilization_ratio: string;
+  blob_params_target: number;
+  blob_params_max: number;
+  target_blobs: number;
+  max_blobs: number;
+  available_blobs: number;
+  utilization_percent: number;
+  is_full: boolean;
+  is_above_target: boolean;
+  update_fraction: number;
+}
+
+export interface BlobPricingRecentBlock {
+  blockNumber: number;
+  blockTimestamp: string;
+  blobCount: number;
+  blobGasUsed: number;
+  blobGasTarget: number;
+  blobGasLimit: number;
+  excessBlobGas: number;
+  blobBaseFee: string;
+  blobBaseFeeGwei: string;
+  utilizationRatio: number;
+  targetBlobs: number;
+  maxBlobs: number;
+  availableBlobs: number;
+  utilizationPercent: number;
+  isFull: boolean;
+  isAboveTarget: boolean;
+}
+
+export interface BackendBlobPricingResponse {
+  network_id: number;
+  network_name: string;
+  current_base_fee: string;
+  current_base_fee_gwei: string;
+  current_excess_gas: number;
+  current_utilization: string;
+  predicted_next_fee: string;
+  predicted_next_fee_gwei: string;
+  fork_stage: string;
+  blob_params: BackendBlobPricingParams;
+  market_pressure: BackendBlobMarketPressure;
+  recent_blocks: BackendBlobPricingRecentBlock[];
+}
+
+export interface BlobPricing {
+  networkId: number;
+  networkName: string;
+  currentBaseFee: string;
+  currentBaseFeeGwei: string;
+  currentExcessGas: number;
+  currentUtilization: number;
+  predictedNextFee: string;
+  predictedNextFeeGwei: string;
+  forkStage: string;
+  blobParams: BlobPricingParams;
+  marketPressure: BlobMarketPressure;
+  recentBlocks: BlobPricingRecentBlock[];
+}
+
 // Backend UserResponse - matches api.UserResponse from swagger
 export interface UserResponse {
   network_id: number;

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,4 +1,13 @@
-import { formatDate, formatNumber, formatWeiToReadable, truncateAddress } from './index';
+import {
+  formatDate,
+  formatDuration,
+  formatGwei,
+  formatNumber,
+  formatPercent,
+  formatWeiToGwei,
+  formatWeiToReadable,
+  truncateAddress
+} from './index';
 
 describe('utils', () => {
   it('formats numbers with locale separators', () => {
@@ -19,5 +28,18 @@ describe('utils', () => {
     expect(formatWeiToReadable('500')).toBe('500 Wei');
     expect(formatWeiToReadable('1000000000')).toContain('Gwei');
     expect(formatWeiToReadable('1000000000000000000')).toContain('ETH');
+  });
+
+  it('formats blob gas fees in gwei', () => {
+    expect(formatWeiToGwei('9389122')).toBe('0.009389 Gwei');
+    expect(formatWeiToGwei('1000000000')).toBe('1 Gwei');
+    expect(formatGwei('0.008487503')).toBe('0.008488 Gwei');
+  });
+
+  it('formats durations and percentages compactly', () => {
+    expect(formatDuration(20.7)).toBe('21 sec');
+    expect(formatDuration(314.03)).toBe('5 min');
+    expect(formatDuration(5400)).toBe('1.5 hr');
+    expect(formatPercent(35.7143)).toBe('35.7%');
   });
 });

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -55,6 +55,9 @@ describe('utils', () => {
   it('formats blob gas fees in gwei', () => {
     expect(formatWeiToGwei('9389122')).toBe('0.009389 Gwei');
     expect(formatWeiToGwei('1000000000')).toBe('1 Gwei');
+    expect(formatWeiToGwei('123456789012345678901234567890')).toBe(
+      '123,456,789,012,345,678,901.234568 Gwei'
+    );
     expect(formatGwei('0.008487503')).toBe('0.008488 Gwei');
   });
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -46,3 +46,54 @@ export function formatWeiToReadable(weiValue: string | number): string {
     return `${wei.toString()} Wei`;
   }
 }
+
+export function formatWeiToGwei(weiValue: string | number, maximumFractionDigits = 6): string {
+  const numericWei = Number(weiValue);
+  if (!Number.isFinite(numericWei)) {
+    return `${weiValue} Wei`;
+  }
+
+  const gwei = numericWei / 1_000_000_000;
+  return `${formatCompactDecimal(gwei, maximumFractionDigits)} Gwei`;
+}
+
+export function formatGwei(gweiValue: string | number, maximumFractionDigits = 6): string {
+  const numericGwei = Number(gweiValue);
+  if (!Number.isFinite(numericGwei)) {
+    return `${gweiValue} Gwei`;
+  }
+
+  return `${formatCompactDecimal(numericGwei, maximumFractionDigits)} Gwei`;
+}
+
+export function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return '0 sec';
+  }
+
+  if (seconds < 60) {
+    return `${Math.round(seconds)} sec`;
+  }
+
+  if (seconds < 3600) {
+    const minutes = Math.round(seconds / 60);
+    return `${minutes} min`;
+  }
+
+  const hours = seconds / 3600;
+  return `${formatCompactDecimal(hours, 1)} hr`;
+}
+
+export function formatPercent(value: number, maximumFractionDigits = 1): string {
+  if (!Number.isFinite(value)) {
+    return '0%';
+  }
+
+  return `${formatCompactDecimal(value, maximumFractionDigits)}%`;
+}
+
+function formatCompactDecimal(value: number, maximumFractionDigits: number): string {
+  return new Intl.NumberFormat('en-US', {
+    maximumFractionDigits,
+  }).format(value);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -67,22 +67,14 @@ export function formatWeiToReadable(weiValue: string | number): string {
 }
 
 export function formatWeiToGwei(weiValue: string | number, maximumFractionDigits = 6): string {
-  const numericWei = Number(weiValue);
-  if (!Number.isFinite(numericWei)) {
-    return `${weiValue} Wei`;
-  }
-
-  const gwei = numericWei / 1_000_000_000;
-  return `${formatCompactDecimal(gwei, maximumFractionDigits)} Gwei`;
+  const rawWeiValue = normalizeDecimalString(weiValue);
+  const gweiValue = formatDecimalUnits(rawWeiValue, 9);
+  return `${formatDecimalString(gweiValue, maximumFractionDigits)} Gwei`;
 }
 
 export function formatGwei(gweiValue: string | number, maximumFractionDigits = 6): string {
-  const numericGwei = Number(gweiValue);
-  if (!Number.isFinite(numericGwei)) {
-    return `${gweiValue} Gwei`;
-  }
-
-  return `${formatCompactDecimal(numericGwei, maximumFractionDigits)} Gwei`;
+  const rawGweiValue = normalizeDecimalString(gweiValue);
+  return `${formatDecimalString(rawGweiValue, maximumFractionDigits)} Gwei`;
 }
 
 export function formatDuration(seconds: number): string {
@@ -156,8 +148,78 @@ function trimTrailingZeros(value: string): string {
   return trimmedValue || '0';
 }
 
+function formatDecimalString(value: string, maximumFractionDigits: number): string {
+  const normalizedValue = normalizeDecimalString(value);
+  const [wholePart, fractionalPart = ''] = normalizedValue.split('.');
+  const fractionDigits = Math.max(0, Math.floor(maximumFractionDigits));
+
+  if (fractionDigits === 0) {
+    return groupIntegerPart(
+      shouldRoundUp(fractionalPart.charAt(0))
+        ? incrementIntegerString(wholePart)
+        : wholePart
+    );
+  }
+
+  let roundedWholePart = wholePart;
+  let roundedFractionalPart = fractionalPart.slice(0, fractionDigits);
+  const nextDigit = fractionalPart.charAt(fractionDigits);
+
+  if (shouldRoundUp(nextDigit)) {
+    const rounded = incrementFractionString(
+      roundedWholePart,
+      roundedFractionalPart.padEnd(fractionDigits, '0')
+    );
+    roundedWholePart = rounded.wholePart;
+    roundedFractionalPart = rounded.fractionalPart;
+  }
+
+  const trimmedFractionalPart = roundedFractionalPart.replace(/0+$/, '');
+  const formattedWholePart = groupIntegerPart(roundedWholePart);
+
+  if (!trimmedFractionalPart) {
+    return formattedWholePart;
+  }
+
+  return `${formattedWholePart}.${trimmedFractionalPart}`;
+}
+
 function formatCompactDecimal(value: number, maximumFractionDigits: number): string {
   return new Intl.NumberFormat('en-US', {
     maximumFractionDigits,
   }).format(value);
+}
+
+function incrementFractionString(wholePart: string, fractionalPart: string) {
+  const digits = fractionalPart.split('');
+
+  for (let index = digits.length - 1; index >= 0; index -= 1) {
+    const nextDigit = Number(digits[index]) + 1;
+    if (nextDigit < 10) {
+      digits[index] = nextDigit.toString();
+      return {
+        wholePart,
+        fractionalPart: digits.join(''),
+      };
+    }
+
+    digits[index] = '0';
+  }
+
+  return {
+    wholePart: incrementIntegerString(wholePart),
+    fractionalPart: digits.join(''),
+  };
+}
+
+function incrementIntegerString(value: string): string {
+  return (BigInt(value) + BigInt(1)).toString();
+}
+
+function groupIntegerPart(value: string): string {
+  return value.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+function shouldRoundUp(value: string): boolean {
+  return value >= '5' && value <= '9';
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -22,6 +22,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- Add typed API clients for `/blob/pricing` and `/blob/mempool/pressure`
- Add a live Blob Market dashboard section for pricing, fork params, includability, fee distribution, and pending age
- Refresh pricing/pressure from `new_block` WebSocket events with a conservative interval fallback
- Add compact wei/gwei/age/percent formatting helpers and API transform coverage

Closes #46.

## Validation
- `npm run typecheck`
- `npm run lint` (passes with existing `<img>` warnings)
- `npm test` (50 tests passed)
- `npm run build`
- Browser verified locally at `http://127.0.0.1:3000` with live pricing/pressure data