### PR TITLE
fix: pulse websocket status on activity

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,3 +40,15 @@
     background-size: 20px 20px;
   }
 }
+
+@keyframes live-activity-pulse {
+  0% {
+    opacity: 0.75;
+    transform: scale(1);
+  }
+
+  100% {
+    opacity: 0;
+    transform: scale(2.4);
+  }
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,14 +20,47 @@ const LIVE_STATUS_STYLES: Record<BlobWebSocketConnectionState, { label: string; 
   disconnected: { label: 'Disconnected', color: 'bg-red' },
 };
 
+interface LiveStatusIndicatorProps {
+  connectionState: BlobWebSocketConnectionState;
+  activitySequence: number;
+  className?: string;
+  labelClassName: string;
+}
+
+function LiveStatusIndicator({
+  connectionState,
+  activitySequence,
+  className,
+  labelClassName,
+}: LiveStatusIndicatorProps) {
+  const liveStatus = LIVE_STATUS_STYLES[connectionState];
+  const containerClassName = className
+    ? `flex items-center space-x-2 ${className}`
+    : 'flex items-center space-x-2';
+  const shouldPulse = connectionState === 'connected' && activitySequence > 0;
+
+  return (
+    <div className={containerClassName}>
+      <div className="relative">
+        <div className={`h-2.5 w-2.5 rounded-full ${liveStatus.color}`}></div>
+        {shouldPulse && (
+          <div
+            key={activitySequence}
+            className={`absolute inset-0 rounded-full ${liveStatus.color} animate-[live-activity-pulse_800ms_ease-out_forwards]`}
+          ></div>
+        )}
+      </div>
+      <span className={labelClassName}>{liveStatus.label}</span>
+    </div>
+  );
+}
+
 export default function Header() {
   const { selectedNetwork, setSelectedNetwork, networkOptions } = useNetwork();
   const { timeRange: selectedTimeRange, setTimeRange: setSelectedTimeRange } = useTimeRange();
-  const { connectionState } = useBlobWebSocket();
+  const { connectionState, activitySequence } = useBlobWebSocket();
   const isMounted = useSyncExternalStore(() => () => {}, () => true, () => false);
   const [isNetworkDropdownOpen, setIsNetworkDropdownOpen] = useState(false);
-  const liveStatus = LIVE_STATUS_STYLES[connectionState];
-  const shouldAnimateLiveStatus = connectionState !== 'disconnected';
   const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
@@ -157,15 +190,12 @@ export default function Header() {
               </button>
 
               {/* Connection Status */}
-              <div className="flex items-center space-x-2 mr-4 ml-1">
-                <div className="relative">
-                  <div className={`h-2.5 w-2.5 rounded-full ${liveStatus.color}`}></div>
-                  {shouldAnimateLiveStatus && (
-                    <div className={`absolute inset-0 rounded-full ${liveStatus.color} opacity-75 animate-ping`}></div>
-                  )}
-                </div>
-                <span className="text-sm text-bodyText">{liveStatus.label}</span>
-              </div>
+              <LiveStatusIndicator
+                connectionState={connectionState}
+                activitySequence={activitySequence}
+                className="mr-4 ml-1"
+                labelClassName="text-sm text-bodyText"
+              />
             </div>
 
             {/* Network Stats */}
@@ -349,15 +379,11 @@ export default function Header() {
               {/* Connection Status */}
               <div className="flex items-center gap-3">
                 <i className="fa-regular fa-signal-stream text-blue" aria-hidden="true"></i>
-                <div className="flex items-center space-x-2">
-                  <div className="relative">
-                    <div className={`h-2.5 w-2.5 rounded-full ${liveStatus.color}`}></div>
-                    {shouldAnimateLiveStatus && (
-                      <div className={`absolute inset-0 rounded-full ${liveStatus.color} opacity-75 animate-ping`}></div>
-                    )}
-                  </div>
-                  <span className="text-base text-bodyText">{liveStatus.label}</span>
-                </div>
+                <LiveStatusIndicator
+                  connectionState={connectionState}
+                  activitySequence={activitySequence}
+                  labelClassName="text-base text-bodyText"
+                />
               </div>
 
               {/* Base Fee */}

--- a/src/contexts/LiveDataContext.tsx
+++ b/src/contexts/LiveDataContext.tsx
@@ -27,6 +27,7 @@ type LiveBlobEventHandler = (event: LiveBlobWebSocketEvent) => void;
 
 interface LiveDataContextValue {
   connectionState: BlobWebSocketConnectionState;
+  activitySequence: number;
   lastEvent: LiveBlobWebSocketEvent | null;
   latestEvents: LatestBlobWebSocketEvents;
   subscribe: (handler: LiveBlobEventHandler) => () => void;
@@ -40,6 +41,7 @@ interface LiveDataProviderProps {
 
 const defaultContextValue: LiveDataContextValue = {
   connectionState: 'disconnected',
+  activitySequence: 0,
   lastEvent: null,
   latestEvents: {},
   subscribe: () => () => {},
@@ -55,6 +57,7 @@ export function LiveDataProvider({
   const handlersRef = useRef(new Set<LiveBlobEventHandler>());
   const [connectionState, setConnectionState] =
     useState<BlobWebSocketConnectionState>('connecting');
+  const [activitySequence, setActivitySequence] = useState(0);
   const [lastEvent, setLastEvent] = useState<LiveBlobWebSocketEvent | null>(null);
   const [latestEvents, setLatestEvents] = useState<LatestBlobWebSocketEvents>({});
   const subscriptionKey = normalizeSubscriptions(subscriptions).join(',');
@@ -79,6 +82,9 @@ export function LiveDataProvider({
       url: buildBlobWebSocketUrl(network),
       subscriptions: normalizedSubscriptions,
       onConnectionStateChange: setConnectionState,
+      onActivity: () => {
+        setActivitySequence((currentSequence) => currentSequence + 1);
+      },
       onEvent: (event) => {
         setLastEvent(event);
         setLatestEvents((currentEvents) => ({
@@ -106,11 +112,12 @@ export function LiveDataProvider({
   const value = useMemo<LiveDataContextValue>(
     () => ({
       connectionState,
+      activitySequence,
       lastEvent,
       latestEvents,
       subscribe,
     }),
-    [connectionState, lastEvent, latestEvents, subscribe]
+    [activitySequence, connectionState, lastEvent, latestEvents, subscribe]
   );
 
   return <LiveDataContext.Provider value={value}>{children}</LiveDataContext.Provider>;

--- a/src/lib/blobWebSocket.test.ts
+++ b/src/lib/blobWebSocket.test.ts
@@ -96,7 +96,10 @@ describe('blobWebSocket', () => {
   it('parses known events and ignores invalid messages', () => {
     expect(parseBlobWebSocketEvent('not json')).toBeNull();
     expect(parseBlobWebSocketEvent(JSON.stringify({ type: 'unknown' }))).toBeNull();
+    expect(parseBlobWebSocketEvent('ping')).toEqual({ type: 'ping' });
+    expect(parseBlobWebSocketEvent('pong')).toEqual({ type: 'pong' });
     expect(parseBlobWebSocketEvent(JSON.stringify({ type: 'ping' }))).toEqual({ type: 'ping' });
+    expect(parseBlobWebSocketEvent(JSON.stringify({ type: 'pong' }))).toEqual({ type: 'pong' });
 
     const parsed = parseBlobWebSocketEvent(
       JSON.stringify({
@@ -139,17 +142,22 @@ describe('blobWebSocket', () => {
     ]);
   });
 
-  it('does not surface ping events to consumers', () => {
+  it('tracks activity but does not surface heartbeat events to consumers', () => {
+    let activityCount = 0;
     const events: LiveBlobWebSocketEvent[] = [];
     const client = new BlobWebSocketClient({
       url: 'wss://example.test/api/v1/ws?network=mainnet',
       WebSocketImpl: MockWebSocket,
+      onActivity: () => {
+        activityCount += 1;
+      },
       onEvent: (event) => events.push(event),
     });
 
     client.connect();
     MockWebSocket.instances[0].open();
     MockWebSocket.instances[0].receive(JSON.stringify({ type: 'ping' }));
+    MockWebSocket.instances[0].receive(JSON.stringify({ type: 'pong' }));
     MockWebSocket.instances[0].receive(
       JSON.stringify({
         type: 'stats_update',
@@ -166,6 +174,7 @@ describe('blobWebSocket', () => {
       })
     );
 
+    expect(activityCount).toBe(3);
     expect(events).toHaveLength(1);
     expect(events[0].type).toBe('stats_update');
   });

--- a/src/lib/blobWebSocket.ts
+++ b/src/lib/blobWebSocket.ts
@@ -50,6 +50,7 @@ interface BlobWebSocketClientOptions {
   maxReconnectDelayMs?: number;
   staleTimeoutMs?: number;
   onConnectionStateChange?: (state: BlobWebSocketConnectionState) => void;
+  onActivity?: () => void;
   onEvent?: (event: LiveBlobWebSocketEvent) => void;
   onError?: (event: Event) => void;
 }
@@ -86,9 +87,14 @@ export function createBlobWebSocketSubscribeMessage(
 
 export function parseBlobWebSocketEvent(message: string): BlobWebSocketEvent | null {
   let payload: unknown;
+  const trimmedMessage = message.trim();
+
+  if (trimmedMessage === 'ping' || trimmedMessage === 'pong') {
+    return { type: trimmedMessage };
+  }
 
   try {
-    payload = JSON.parse(message);
+    payload = JSON.parse(trimmedMessage);
   } catch {
     return null;
   }
@@ -100,6 +106,8 @@ export function parseBlobWebSocketEvent(message: string): BlobWebSocketEvent | n
   switch (payload.type) {
     case 'ping':
       return { type: 'ping' };
+    case 'pong':
+      return { type: 'pong' };
     case 'new_block':
       if (isRecord(payload.data)) {
         return { type: 'new_block', data: payload.data as unknown as NewBlockData };
@@ -172,7 +180,12 @@ export class BlobWebSocketClient {
 
       this.resetStaleTimer();
       const parsedEvent = parseBlobWebSocketEvent(event.data);
-      if (!parsedEvent || parsedEvent.type === 'ping') {
+      if (!parsedEvent) {
+        return;
+      }
+
+      this.options.onActivity?.();
+      if (parsedEvent.type === 'ping' || parsedEvent.type === 'pong') {
         return;
       }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,7 +48,7 @@ export type SubscribableBlobEventType =
   | 'stats_update'
   | 'users_update';
 
-export type BlobWebSocketEventType = SubscribableBlobEventType | 'ping';
+export type BlobWebSocketEventType = SubscribableBlobEventType | 'ping' | 'pong';
 
 export interface NewBlockData {
   block_number: number;
@@ -94,14 +94,20 @@ export interface PingEvent {
   type: 'ping';
 }
 
+export interface PongEvent {
+  type: 'pong';
+}
+
+export type HeartbeatEvent = PingEvent | PongEvent;
+
 export type BlobWebSocketEvent =
   | NewBlockEvent
   | MempoolUpdateEvent
   | StatsUpdateEvent
   | UsersUpdateEvent
-  | PingEvent;
+  | HeartbeatEvent;
 
-export type LiveBlobWebSocketEvent = Exclude<BlobWebSocketEvent, PingEvent>;
+export type LiveBlobWebSocketEvent = Exclude<BlobWebSocketEvent, HeartbeatEvent>;
 
 export interface BlobWebSocketEventMap {
   new_block: NewBlockEvent;


### PR DESCRIPTION
## Summary
- Drive the header connection indicator from websocket lifecycle state instead of a constant non-disconnected animation.
- Emit an activity sequence for parsed websocket messages, including JSON and plain-text ping/pong heartbeats.
- Reuse the desktop/mobile status indicator and add a finite pulse animation that only runs while connected.

## Root Cause
The connected icon used `animate-ping` whenever the state was anything except `disconnected`, so connecting, stale, and reconnecting states could look actively healthy even without websocket traffic.

## Impact
Users now see the dot color reflect actual websocket connectivity, with short pulses only when live data or heartbeat traffic is received.

## Validation
- `npm test`
- `npm run typecheck`
- `npm run lint` (passes with existing `<img>` warnings)
- `npm run build`
- Local browser smoke test on `localhost:3001`
