### PR TITLE
fix: format average total cost from wei

### DIFF
--- a/src/lib/api/stats.test.ts
+++ b/src/lib/api/stats.test.ts
@@ -18,7 +18,7 @@ describe('api/stats', () => {
           total_pending_blobs: 20,
           average_base_fee: '1000000000',
           average_tip: '2000000000',
-          average_total_cost: '3000000000',
+          average_total_cost: '500000000000000',
           last_indexed_block: 12345,
           last_indexed_time: '2026-01-01T00:00:00.000Z',
         },
@@ -41,21 +41,22 @@ describe('api/stats', () => {
       lastIndexedBlock: 12345,
     });
     expect(result.data.averageBaseFee).toContain('Gwei');
+    expect(result.data.averageTotalCost).toBe('0.0005 ETH');
   });
 
-  it('formats websocket decimal average total cost as ETH', () => {
+  it('formats websocket fractional wei average total cost as ETH', () => {
     const result = transformStatsResponse({
       total_blobs: 100,
       total_confirmed_blobs: 80,
       total_pending_blobs: 20,
       average_base_fee: '5014755072.74762611',
       average_tip: '2000000000',
-      average_total_cost: '0.001',
+      average_total_cost: '2203603226459001.927',
       last_indexed_block: 12345,
       last_indexed_time: '2026-01-01T00:00:00.000Z',
     });
 
     expect(result.data.averageBaseFee).toContain('Gwei');
-    expect(result.data.averageTotalCost).toBe('0.001 ETH');
+    expect(result.data.averageTotalCost).toBe('0.002203603226459001927 ETH');
   });
 });

--- a/src/lib/api/stats.ts
+++ b/src/lib/api/stats.ts
@@ -1,6 +1,6 @@
 import { StatsResponse, ApiResponse, BackendStatsResponse, WebSocketStatsResponse } from '../../types';
 import { fetchApi } from './core';
-import { formatCostEthOrWei, formatWeiToReadable } from '../../utils';
+import { formatWeiToEth, formatWeiToReadable } from '../../utils';
 
 export function transformStatsResponse(stats: BackendStatsResponse | WebSocketStatsResponse): StatsResponse {
     return {
@@ -11,7 +11,7 @@ export function transformStatsResponse(stats: BackendStatsResponse | WebSocketSt
             pendingBlobsCount: stats.total_pending_blobs,
             avgBlobsPerBlock: Math.round(((stats.total_confirmed_blobs || 100) / 100) * 10) / 10,
             averageTip: formatWeiToReadable(stats.average_tip || '0'),
-            averageTotalCost: formatCostEthOrWei(stats.average_total_cost || '0'),
+            averageTotalCost: formatWeiToEth(stats.average_total_cost || '0'),
             lastIndexedBlock: stats.last_indexed_block,
             lastIndexedTime: stats.last_indexed_time
         }

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -2,6 +2,7 @@ import {
   formatCostEthOrWei,
   formatDate,
   formatNumber,
+  formatWeiToEth,
   formatWeiToReadable,
   getAttributionImageSrc,
   getAttributionInitial,
@@ -30,6 +31,11 @@ describe('utils', () => {
     expect(formatWeiToReadable('1000000000')).toBe('1 Gwei');
     expect(formatWeiToReadable('5014755072.74762611')).toBe('5.01475507274762611 Gwei');
     expect(formatWeiToReadable('1000000000000000000')).toBe('1 ETH');
+  });
+
+  it('formats wei values explicitly as ETH', () => {
+    expect(formatWeiToEth('500000000000000')).toBe('0.0005 ETH');
+    expect(formatWeiToEth('2203603226459001.927')).toBe('0.002203603226459001927 ETH');
   });
 
   it('formats decimal ETH costs and integer wei costs', () => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -66,6 +66,11 @@ export function formatWeiToReadable(weiValue: string | number): string {
   }
 }
 
+export function formatWeiToEth(weiValue: string | number): string {
+  const rawWeiValue = normalizeDecimalString(weiValue);
+  return `${formatDecimalUnits(rawWeiValue, 18)} ETH`;
+}
+
 export function formatCostEthOrWei(costEthOrWei: string | number): string {
   const rawCost = normalizeDecimalString(costEthOrWei);
 


### PR DESCRIPTION
## Summary

- Add an explicit wei-to-ETH formatter for cost values that must be displayed as ETH.
- Use it for the live stats average total cost transform.
- Add regression coverage for fractional wei averages from the stats feed.

## Root Cause

The stats API returns `average_total_cost` in wei, including a fractional component for averaged values. The UI previously treated any decimal cost string as already denominated in ETH, so fractional wei values were displayed as enormous ETH values.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated `<img>` warnings)
- `npm run build`