### PR TITLE
feat: add mempool blob details modal

### DIFF
--- a/src/components/MempoolBlobDetailsModal.tsx
+++ b/src/components/MempoolBlobDetailsModal.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import Image from 'next/image';
+import React, { useEffect, useRef } from 'react';
+import useScrollLock from '../hooks/useScrollLock';
+import { MempoolTransaction } from '../types';
+import {
+  formatCostEthOrWei,
+  formatWeiToReadable,
+  getAttributionImageSrc,
+  getAttributionInitial,
+} from '../utils';
+
+interface MempoolBlobDetailsModalProps {
+  transaction: MempoolTransaction | null;
+  onClose: () => void;
+}
+
+export default function MempoolBlobDetailsModal({
+  transaction,
+  onClose,
+}: MempoolBlobDetailsModalProps) {
+  const isOpen = transaction !== null;
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  useScrollLock(isOpen);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    closeButtonRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!transaction) return null;
+
+  const blob = transaction.rawBlob;
+  const user = blob.user_attribution || 'Unknown';
+  const imageSrc = getAttributionImageSrc(user);
+  const blockValue =
+    blob.confirmed && blob.block_number > 0 ? blob.block_number.toLocaleString() : 'Pending';
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/60 px-3 py-4 backdrop-blur-[1px] sm:items-center sm:p-6"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mempool-blob-details-title"
+        className="w-full max-w-2xl overflow-hidden rounded-lg border border-divider bg-[#14161a] shadow-2xl"
+      >
+        <div className="flex items-start justify-between gap-4 border-b border-divider bg-gradient-to-b from-[#22252c] to-[#16171b] px-5 py-4">
+          <div className="min-w-0">
+            <p className="mb-1 text-xs font-medium uppercase tracking-wider text-[#6e7787]">
+              Pending Blob
+            </p>
+            <h3 id="mempool-blob-details-title" className="truncate font-mono text-base text-white">
+              {truncateTxHash(transaction.txHash)}
+            </h3>
+          </div>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={onClose}
+            aria-label="Close blob details"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-divider text-xl leading-none text-[#b8bdc7] transition-colors hover:border-[#3B55E6] hover:text-white focus:outline-none focus:ring-2 focus:ring-[#3B55E6]"
+          >
+            x
+          </button>
+        </div>
+
+        <div className="max-h-[76vh] overflow-y-auto px-5 py-5">
+          <div className="mb-5 flex flex-wrap items-center gap-3">
+            <span className="inline-flex items-center rounded-full border border-[#3B55E6]/40 bg-[#1E2747] px-3 py-1 text-xs font-medium uppercase tracking-wider text-[#9ac4fd]">
+              {blob.confirmed ? 'Confirmed' : 'Pending'}
+            </span>
+            <span className="text-sm text-[#b8bdc7]">
+              {blob.network_name || `Network ${blob.network_id}`}
+            </span>
+            <span className="text-sm text-[#6e7687]">{transaction.timeInMempool}</span>
+          </div>
+
+          <div className="mb-6 flex items-center gap-3 border-b border-divider pb-5">
+            {imageSrc ? (
+              <Image src={imageSrc} alt="" width={32} height={32} className="h-8 w-8" />
+            ) : (
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-gray-500 text-sm font-medium text-white">
+                {getAttributionInitial(user)}
+              </span>
+            )}
+            <div>
+              <div className="text-xs uppercase tracking-wider text-[#6e7787]">User</div>
+              <div className="text-sm font-medium text-white">{user}</div>
+            </div>
+          </div>
+
+          <dl className="grid grid-cols-1 gap-x-5 gap-y-4 sm:grid-cols-2">
+            <DetailItem label="Transaction Hash" value={transaction.txHash} mono full />
+            <DetailItem label="From Address" value={blob.from_address} mono full />
+            <DetailItem label="Block" value={blockValue} />
+            <DetailItem label="Blob Index" value={blob.blob_index.toString()} />
+            <DetailItem label="Blob Size" value={formatBlobSize(blob.blob_size_bytes)} />
+            <DetailItem label="Blob Gas Used" value={formatNumber(blob.blob_gas_used)} />
+            <DetailItem label="Base Fee" value={safeFormatWei(blob.base_fee_per_blob_gas)} />
+            <DetailItem label="Tip" value={safeFormatWei(blob.tip_per_blob_gas)} />
+            <DetailItem label="Max Fee" value={safeFormatWei(blob.max_fee_per_blob_gas)} />
+            <DetailItem label="Estimated Cost" value={safeFormatCost(blob.total_cost_eth)} />
+            <DetailItem label="First Seen" value={formatTimestamp(blob.timestamp)} full />
+          </dl>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+interface DetailItemProps {
+  label: string;
+  value: string;
+  mono?: boolean;
+  full?: boolean;
+}
+
+function DetailItem({ label, value, mono = false, full = false }: DetailItemProps) {
+  const valueClasses = `${mono ? 'font-mono ' : ''}break-words text-sm text-white`;
+
+  return (
+    <div className={full ? 'sm:col-span-2' : undefined}>
+      <dt className="mb-1 text-xs uppercase tracking-wider text-[#6e7787]">{label}</dt>
+      <dd className={valueClasses}>{value}</dd>
+    </div>
+  );
+}
+
+function truncateTxHash(hash: string): string {
+  if (hash.length <= 18) return hash;
+  return `${hash.substring(0, 10)}...${hash.substring(hash.length - 6)}`;
+}
+
+function formatNumber(value: number | undefined): string {
+  return value === undefined ? '-' : value.toLocaleString();
+}
+
+function formatBlobSize(value: number): string {
+  if (value <= 0) return '-';
+  return `${(value / 1024).toFixed(1)} KB`;
+}
+
+function safeFormatWei(value: string | undefined): string {
+  if (!value) return '-';
+
+  try {
+    return formatWeiToReadable(value);
+  } catch {
+    return value;
+  }
+}
+
+function safeFormatCost(value: string | undefined): string {
+  if (!value) return '-';
+
+  try {
+    return formatCostEthOrWei(value);
+  } catch {
+    return value;
+  }
+}
+
+function formatTimestamp(timestamp: string): string {
+  const date = new Date(timestamp);
+
+  if (Number.isNaN(date.getTime())) {
+    return timestamp;
+  }
+
+  return date.toLocaleString('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+  });
+}

--- a/src/components/MempoolTable.test.tsx
+++ b/src/components/MempoolTable.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { DEFAULT_NETWORK } from '../constants';
+import { useBlobWebSocket } from '../contexts/LiveDataContext';
+import { useApiData } from '../hooks/useApiData';
+import { useNetwork } from '../hooks/useNetwork';
+import { transformBlobToMempoolTransaction } from '../lib/api/mempool';
+import { BlobResponse, MempoolResponse } from '../types';
+import MempoolTable from './MempoolTable';
+
+vi.mock('../hooks/useApiData', () => ({
+  useApiData: vi.fn(),
+}));
+
+vi.mock('../hooks/useNetwork', () => ({
+  useNetwork: vi.fn(),
+}));
+
+vi.mock('../contexts/LiveDataContext', () => ({
+  useBlobWebSocket: vi.fn(),
+}));
+
+const blob: BlobResponse = {
+  network_id: 1,
+  network_name: 'mainnet',
+  block_number: 0,
+  blob_index: 2,
+  tx_hash: '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+  from_address: '0x1234567890abcdef1234567890abcdef12345678',
+  blob_size_bytes: 131072,
+  base_fee_per_blob_gas: '1000000000',
+  tip_per_blob_gas: '100000000',
+  total_cost_eth: '0.001',
+  timestamp: '2026-01-01T00:00:00.000Z',
+  confirmed: false,
+  user_attribution: 'Base',
+  max_fee_per_blob_gas: '2000000000',
+  blob_gas_used: 131072,
+};
+
+describe('MempoolTable', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'scrollTo', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    vi.mocked(useNetwork).mockReturnValue({
+      selectedNetwork: DEFAULT_NETWORK,
+      setSelectedNetwork: vi.fn(),
+      networkOptions: [DEFAULT_NETWORK],
+    });
+    vi.mocked(useBlobWebSocket).mockReturnValue({
+      connectionState: 'disconnected',
+      lastEvent: null,
+      latestEvents: {},
+      subscribe: () => () => {},
+    });
+    vi.mocked(useApiData<MempoolResponse>).mockReturnValue({
+      data: {
+        data: [transformBlobToMempoolTransaction(blob, 0)],
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  it('opens pending blob details from the transaction hash', () => {
+    render(<MempoolTable />);
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: `View pending blob details for transaction ${blob.tx_hash}`,
+      })
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(blob.tx_hash)).toBeInTheDocument();
+    expect(screen.getByText(blob.from_address)).toBeInTheDocument();
+    expect(screen.getByText('Blob Index')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /close blob details/i }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/MempoolTable.tsx
+++ b/src/components/MempoolTable.tsx
@@ -9,10 +9,12 @@ import { useNetwork } from '../hooks/useNetwork';
 import { getAttributionImageSrc, getAttributionInitial } from '../utils';
 import { useBlobWebSocket } from '../contexts/LiveDataContext';
 import { transformBlobToMempoolTransaction } from '../lib/api/mempool';
+import MempoolBlobDetailsModal from './MempoolBlobDetailsModal';
 
 export default function MempoolTable() {
   const { selectedNetwork } = useNetwork();
   const { latestEvents } = useBlobWebSocket();
+  const [selectedTransaction, setSelectedTransaction] = React.useState<MempoolTransaction | null>(null);
 
   const { data, isLoading, error } = useApiData<MempoolResponse>(
     () => api.getMempool(10, selectedNetwork.apiParam),
@@ -119,8 +121,17 @@ export default function MempoolTable() {
               </thead>
               <tbody className="divide-y divide-divider">
                 {displayData.data.map((tx: MempoolTransaction) => (
-                  <tr key={tx.id} className="bg-gradient-to-r from-[#161a29] to-[#19191e]/60 hover:bg-gradient-to-r hover:from-[#202538]/70 hover:to-[#242731]/70 transition-colors">
-                    <td className="py-3 px-6 text-sm font-mono text-white">{truncateTxHash(tx.txHash)}</td>
+                  <tr key={`${tx.txHash}-${tx.rawBlob.blob_index}`} className="bg-gradient-to-r from-[#161a29] to-[#19191e]/60 hover:bg-gradient-to-r hover:from-[#202538]/70 hover:to-[#242731]/70 transition-colors">
+                    <td className="py-3 px-6 text-sm font-mono text-white">
+                      <button
+                        type="button"
+                        onClick={() => setSelectedTransaction(tx)}
+                        className="cursor-pointer rounded text-left text-white underline decoration-[#3B55E6]/50 underline-offset-4 transition-colors hover:text-[#9ac4fd] focus:outline-none focus:ring-2 focus:ring-[#3B55E6] focus:ring-offset-2 focus:ring-offset-[#161a29]"
+                        aria-label={`View pending blob details for transaction ${tx.txHash}`}
+                      >
+                        {truncateTxHash(tx.txHash)}
+                      </button>
+                    </td>
                     <td className="py-3 px-6 text-sm font-mono text-white">{tx.fromAddress}</td>
                     <td className="py-3 px-6 text-sm text-white">
                       {tx.user ? (
@@ -155,6 +166,10 @@ export default function MempoolTable() {
           </div>
         )}
       </DataStateWrapper>
+      <MempoolBlobDetailsModal
+        transaction={selectedTransaction}
+        onClose={() => setSelectedTransaction(null)}
+      />
     </section>
   );
 }

--- a/src/lib/api/mempool.test.ts
+++ b/src/lib/api/mempool.test.ts
@@ -48,6 +48,10 @@ describe('api/mempool', () => {
       user: 'Base',
       blobCount: 1,
       timeInMempool: '5 min ago',
+      rawBlob: expect.objectContaining({
+        tx_hash: '0xabc',
+        from_address: '0x1234567890abcdef',
+      }),
     });
     expect(result.data[0].estimatedCost).toContain('Gwei');
   });

--- a/src/lib/api/mempool.ts
+++ b/src/lib/api/mempool.ts
@@ -10,7 +10,8 @@ export function transformBlobToMempoolTransaction(blob: BlobResponse, index: num
         user: blob.user_attribution || null,
         blobCount: 1,
         estimatedCost: formatCostEthOrWei(blob.total_cost_eth),
-        timeInMempool: formatRelativeTime(blob.timestamp)
+        timeInMempool: formatRelativeTime(blob.timestamp),
+        rawBlob: blob,
     };
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -141,6 +141,7 @@ export interface MempoolTransaction {
   blobCount: number;
   estimatedCost: string;
   timeInMempool: string;
+  rawBlob: BlobResponse;
 }
 
 // Mempool response (frontend-shaped)


### PR DESCRIPTION
## Summary
- Make pending mempool transaction hashes clickable.
- Add a focused pending blob details modal with transaction, sender, network, blob, fee, cost, and timestamp fields.
- Preserve the raw blob payload in mempool row data so fetched and live updates can show details without an extra request.
- Add coverage for the mempool transform and table modal interaction.

## Impact
Users can inspect pending blobs directly from the mempool table instead of only seeing the compact row values.

## Validation
- `npm run typecheck`
- `npm run lint` (0 errors; existing `<img>` warnings remain)
- `npm test`
- `npm run build`
- Browser smoke test on local dev server: opened and closed a pending blob details modal.