### PR TITLE
fix: reduce duplicate dashboard backend requests

### DIFF
--- a/src/components/LatestBlocksTable.tsx
+++ b/src/components/LatestBlocksTable.tsx
@@ -9,19 +9,20 @@ import { useNetwork } from '../hooks/useNetwork';
 import { getAttributionImageSrc, getAttributionInitial } from '../utils';
 import { useBlobWebSocket } from '../contexts/LiveDataContext';
 import { transformNewBlockData } from '../lib/api/blocks';
+import { DASHBOARD_LATEST_BLOB_LIMIT, LATEST_BLOCK_ROWS } from '../constants';
 
 export default function LatestBlocksTable() {
   const { selectedNetwork } = useNetwork();
   const { latestEvents } = useBlobWebSocket();
 
   const { data, isLoading, error } = useApiData<LatestBlocksResponse>(
-    () => api.getLatestBlocks(20, selectedNetwork.apiParam),
+    () => api.getLatestBlocks(DASHBOARD_LATEST_BLOB_LIMIT, selectedNetwork.apiParam),
     undefined,
     selectedNetwork.apiParam
   );
   const displayData = React.useMemo<LatestBlocksResponse | undefined>(() => {
     if (!latestEvents.new_block) {
-      return data;
+      return data ? { data: data.data.slice(0, LATEST_BLOCK_ROWS) } : undefined;
     }
 
     const liveBlock = transformNewBlockData(latestEvents.new_block.data);
@@ -29,7 +30,7 @@ export default function LatestBlocksTable() {
       data: [
         liveBlock,
         ...(data?.data || []).filter((block) => block.number !== liveBlock.number),
-      ].slice(0, 20),
+      ].slice(0, LATEST_BLOCK_ROWS),
     };
   }, [data, latestEvents.new_block]);
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,6 +4,8 @@
 
 export const APP_NAME = 'Blob Flow';
 export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://blob-indexer.ahkc.win/api/v1';
+export const DASHBOARD_LATEST_BLOB_LIMIT = 200;
+export const LATEST_BLOCK_ROWS = 20;
 
 /**
  * Network configuration

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -6,11 +6,12 @@ import { useTimeRange } from '../contexts/TimeRangeContext';
 import { useNetwork } from './useNetwork';
 import { api } from '../lib/api';
 import { aggregateChartData } from '../lib/chartAggregation';
+import { DASHBOARD_LATEST_BLOB_LIMIT } from '../constants';
 import type { BlobResponse, ChartDataset, StatsResponse } from '../types';
 
 function getLimitForRange(range: string): number {
   switch (range) {
-    case '24h': return 200;
+    case '24h': return DASHBOARD_LATEST_BLOB_LIMIT;
     case '7d': return 500;
     case '30d': return 1000;
     case 'All': return 1000;

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -15,7 +15,7 @@ function getLimitForRange(range: string): number {
     case '7d': return 500;
     case '30d': return 1000;
     case 'All': return 1000;
-    default: return 200;
+    default: return DASHBOARD_LATEST_BLOB_LIMIT;
   }
 }
 

--- a/src/lib/api/core.test.ts
+++ b/src/lib/api/core.test.ts
@@ -50,6 +50,36 @@ describe('api/core', () => {
     );
   });
 
+  it('deduplicates matching concurrent GET requests', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const [firstResult, secondResult] = await Promise.all([
+      fetchApi<{ success: boolean }>('/stats', 'mainnet'),
+      fetchApi<{ success: boolean }>('/stats', 'mainnet'),
+    ]);
+
+    expect(firstResult).toEqual({ success: true });
+    expect(secondResult).toEqual({ success: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache completed GET requests', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await fetchApi<{ success: boolean }>('/stats', 'mainnet');
+    await fetchApi<{ success: boolean }>('/stats', 'mainnet');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('retries on 5xx and eventually succeeds', async () => {
     vi.useFakeTimers();
     const fetchMock = vi

--- a/src/lib/api/core.test.ts
+++ b/src/lib/api/core.test.ts
@@ -80,6 +80,33 @@ describe('api/core', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it('does not deduplicate GET requests with custom options', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ user: 'first' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ user: 'second' }),
+      });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const [firstResult, secondResult] = await Promise.all([
+      fetchApi<{ user: string }>('/stats', 'mainnet', {
+        headers: { Authorization: 'Bearer first' },
+      }),
+      fetchApi<{ user: string }>('/stats', 'mainnet', {
+        headers: { Authorization: 'Bearer second' },
+      }),
+    ]);
+
+    expect(firstResult).toEqual({ user: 'first' });
+    expect(secondResult).toEqual({ user: 'second' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('retries on 5xx and eventually succeeds', async () => {
     vi.useFakeTimers();
     const fetchMock = vi

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -128,6 +128,10 @@ function getInFlightGetRequestKey(url: string, options?: RequestInit): string | 
         return null;
     }
 
+    if (hasRequestOptionsThatAffectResponse(options)) {
+        return null;
+    }
+
     return `${method}:${url}`;
 }
 
@@ -135,4 +139,12 @@ function clearInFlightGetRequest(key: string, request: Promise<unknown>) {
     if (inFlightGetRequests.get(key) === request) {
         inFlightGetRequests.delete(key);
     }
+}
+
+function hasRequestOptionsThatAffectResponse(options?: RequestInit): boolean {
+    if (!options) {
+        return false;
+    }
+
+    return Object.keys(options).some((key) => key !== 'method');
 }

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -6,6 +6,8 @@ import { API_BASE_URL } from '../../constants';
 export const DEFAULT_TIMEOUT_MS = 10000;
 export const MAX_RETRIES = 2;
 
+const inFlightGetRequests = new Map<string, Promise<unknown>>();
+
 /**
  * Helper function to format relative time
  */
@@ -54,7 +56,34 @@ export async function fetchApi<T>(
     // Add network parameter to the endpoint if provided
     const networkParam = network ? `${endpoint.includes('?') ? '&' : '?'}network=${network}` : '';
     const url = `${API_BASE_URL}${endpoint}${networkParam}`;
+    const requestKey = retries === 0 ? getInFlightGetRequestKey(url, options) : null;
+    const inFlightRequest = requestKey ? inFlightGetRequests.get(requestKey) : undefined;
 
+    if (inFlightRequest) {
+        return inFlightRequest as Promise<T>;
+    }
+
+    const request = performFetchApi<T>(url, endpoint, network, options, timeoutMs, retries);
+
+    if (requestKey) {
+        inFlightGetRequests.set(requestKey, request);
+        request.then(
+            () => clearInFlightGetRequest(requestKey, request),
+            () => clearInFlightGetRequest(requestKey, request)
+        );
+    }
+
+    return request;
+}
+
+async function performFetchApi<T>(
+    url: string,
+    endpoint: string,
+    network?: string,
+    options?: RequestInit,
+    timeoutMs: number = DEFAULT_TIMEOUT_MS,
+    retries: number = 0
+): Promise<T> {
     // Create abort controller for timeout
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
@@ -90,5 +119,20 @@ export async function fetchApi<T>(
         clearTimeout(timeoutId);
         console.error('API fetch error:', error);
         throw new Error('API request failed');
+    }
+}
+
+function getInFlightGetRequestKey(url: string, options?: RequestInit): string | null {
+    const method = (options?.method || 'GET').toUpperCase();
+    if (method !== 'GET') {
+        return null;
+    }
+
+    return `${method}:${url}`;
+}
+
+function clearInFlightGetRequest(key: string, request: Promise<unknown>) {
+    if (inFlightGetRequests.get(key) === request) {
+        inFlightGetRequests.delete(key);
     }
 }


### PR DESCRIPTION
## Summary

- Add in-flight deduplication for matching concurrent GET requests in the shared API client.
- Make the latest-blocks table bootstrap from the same 200-blob `/blob/latest` request used by the default 24h charts, while still rendering only the latest 20 rows.
- Add API client tests covering concurrent dedupe and confirming completed requests are not cached.

## Why

The dashboard already uses WebSocket events for live updates, but cold page loads could still fan out overlapping REST work. On the home page, `/stats` was requested by both live metrics and charts, and `/blob/latest` was requested by both latest blocks and charts with overlapping data needs. In development, React strict mode can amplify those mount-time requests, and backend 5xx retries can multiply the impact when the backend is already unhealthy.

With this change, the default home bootstrap should collapse the duplicate `/stats` and `/blob/latest?limit=200` calls, reducing the initial REST burst from about six logical calls to four backend requests per tab, plus the single existing WebSocket connection.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint` (passes with existing `@next/next/no-img-element` warnings)
- `npm run build`
