### PR TITLE
feat: animate row updates in live tables

### DIFF
--- a/src/components/LatestBlocksTable.tsx
+++ b/src/components/LatestBlocksTable.tsx
@@ -23,6 +23,7 @@ import { useBlobWebSocket } from '../contexts/LiveDataContext';
 import { transformNewBlockData } from '../lib/api/blocks';
 import { formatRelativeTime } from '../lib/api/core';
 import { DASHBOARD_LATEST_BLOB_LIMIT, LATEST_BLOCK_ROWS } from '../constants';
+import { useFlipRows } from '../hooks/useFlipRows';
 
 function getBlockDetailsId(blockId: number): string {
   return `block-${blockId}-blob-details`;
@@ -199,7 +200,11 @@ function BlobDetailField({
 
 function BlobDetailsRow({ block }: { block: Block }) {
   return (
-    <tr id={getBlockDetailsId(block.id)} className="bg-[#111522]">
+    <tr
+      id={getBlockDetailsId(block.id)}
+      data-row-key={`details-${block.id}`}
+      className="bg-[#111522]"
+    >
       <td colSpan={6} className="p-0">
         <div className="px-4 sm:px-6 py-4 border-t border-dividerBlue/50">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
@@ -308,6 +313,8 @@ export default function LatestBlocksTable() {
     undefined,
     selectedNetwork.apiParam
   );
+  const tbodyRef = React.useRef<HTMLTableSectionElement | null>(null);
+  useFlipRows(tbodyRef, selectedNetwork.apiParam);
   const displayData = React.useMemo<LatestBlocksResponse | undefined>(() => {
     if (!latestEvents.new_block) {
       return data ? { data: data.data.slice(0, LATEST_BLOCK_ROWS) } : undefined;
@@ -426,7 +433,7 @@ export default function LatestBlocksTable() {
                   <th className="hidden lg:table-cell py-3 px-3 sm:px-4 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-[12%]">Users</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-divider">
+              <tbody ref={tbodyRef} className="divide-y divide-divider">
                 {displayData.data.map((block: Block) => {
                   const isExpanded = expandedBlockId === block.id;
                   const detailsId = getBlockDetailsId(block.id);
@@ -437,6 +444,7 @@ export default function LatestBlocksTable() {
                   return (
                     <React.Fragment key={block.id}>
                       <tr
+                        data-row-key={`block-${block.id}`}
                         className={`bg-gradient-to-r transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-blue focus-visible:ring-inset ${
                           isExpanded
                             ? 'from-[#202538]/80 to-[#242731]/70'

--- a/src/components/MempoolTable.tsx
+++ b/src/components/MempoolTable.tsx
@@ -15,12 +15,15 @@ import {
 } from '../utils';
 import { useBlobWebSocket } from '../contexts/LiveDataContext';
 import { transformBlobToMempoolTransaction } from '../lib/api/mempool';
+import { useFlipRows } from '../hooks/useFlipRows';
 import MempoolBlobDetailsModal from './MempoolBlobDetailsModal';
 
 export default function MempoolTable() {
   const { selectedNetwork } = useNetwork();
   const { latestEvents } = useBlobWebSocket();
   const [selectedTransaction, setSelectedTransaction] = React.useState<MempoolTransaction | null>(null);
+  const tbodyRef = React.useRef<HTMLTableSectionElement | null>(null);
+  useFlipRows(tbodyRef, selectedNetwork.apiParam);
 
   const { data, isLoading, error } = useApiData<MempoolResponse>(
     () => api.getMempool(10, selectedNetwork.apiParam),
@@ -122,14 +125,16 @@ export default function MempoolTable() {
                   <th className="hidden md:table-cell py-3 px-3 sm:px-4 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-[12%] whitespace-nowrap">Time</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-divider">
+              <tbody ref={tbodyRef} className="divide-y divide-divider">
                 {displayData.data.map((tx: MempoolTransaction) => {
                   const user = tx.user || 'Unknown';
                   const userImageSrc = getAttributionImageSrc(user);
+                  const rowKey = `${tx.txHash}-${tx.rawBlob.blob_index}`;
 
                   return (
                     <tr
-                      key={`${tx.txHash}-${tx.rawBlob.blob_index}`}
+                      key={rowKey}
+                      data-row-key={rowKey}
                       className="bg-gradient-to-r from-[#161a29] to-[#19191e]/60 hover:bg-gradient-to-r hover:from-[#202538]/70 hover:to-[#242731]/70 transition-colors"
                     >
                       <td className="py-3 px-3 sm:px-4 text-sm font-mono text-white">

--- a/src/components/TopUsersTable.tsx
+++ b/src/components/TopUsersTable.tsx
@@ -11,6 +11,7 @@ import { useNetwork } from '../hooks/useNetwork';
 import { getAttributionImageSrc, getAttributionInitial } from '../utils';
 import { useBlobWebSocket } from '../contexts/LiveDataContext';
 import { transformUserResponses } from '../lib/api/users';
+import { useFlipRows } from '../hooks/useFlipRows';
 
 export default function TopUsersTable() {
   const router = useRouter();
@@ -25,6 +26,8 @@ export default function TopUsersTable() {
   const displayData = latestEvents.users_update
     ? transformUserResponses(latestEvents.users_update.data)
     : data;
+  const tbodyRef = React.useRef<HTMLTableSectionElement | null>(null);
+  useFlipRows(tbodyRef, selectedNetwork.apiParam);
 
   useEffect(() => {
     const setupTooltips = () => {
@@ -198,13 +201,14 @@ export default function TopUsersTable() {
                   <th className="py-3 px-6 text-left text-xs font-medium text-[#6e7787] uppercase tracking-wider w-1/3">% of Total</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-divider">
+              <tbody ref={tbodyRef} className="divide-y divide-divider">
                 {displayData.data.map((user: User) => {
                   const imageSrc = getAttributionImageSrc(user.name);
 
                   return (
                     <tr
                       key={user.address}
+                      data-row-key={user.address}
                       className="bg-gradient-to-r from-[#161a29] to-[#19191e]/60 hover:bg-gradient-to-r hover:from-[#202538]/70 hover:to-[#242731]/70 transition-colors cursor-pointer"
                       onClick={() => router.push(`/user/${user.address}`)}
                     >

--- a/src/hooks/useFlipRows.test.tsx
+++ b/src/hooks/useFlipRows.test.tsx
@@ -1,0 +1,302 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useFlipRows } from './useFlipRows';
+
+interface TestTableProps {
+  rows: string[];
+  resetKey?: unknown;
+  mountTbody?: boolean;
+}
+
+function TestTable({ rows, resetKey, mountTbody = true }: TestTableProps) {
+  const tbodyRef = React.useRef<HTMLTableSectionElement>(null);
+  useFlipRows(tbodyRef, resetKey);
+  if (!mountTbody) return null;
+  return (
+    <table>
+      <tbody ref={tbodyRef}>
+        {rows.map((k) => (
+          <tr key={k} data-row-key={k}>
+            <td>{k}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+type FakeAnimation = {
+  finish: ReturnType<typeof vi.fn>;
+  cancel: ReturnType<typeof vi.fn>;
+  keyframes: Keyframe[] | PropertyIndexedKeyframes | null;
+  options: KeyframeAnimationOptions | number | undefined;
+};
+
+type AnimateMock = ReturnType<typeof vi.fn>;
+
+function installAnimate(
+  impl?: (keyframes: Keyframe[] | PropertyIndexedKeyframes | null, options?: KeyframeAnimationOptions | number) => FakeAnimation
+): { animations: FakeAnimation[]; spy: AnimateMock } {
+  const animations: FakeAnimation[] = [];
+  const spy = vi.fn(function (
+    this: HTMLElement,
+    keyframes: Keyframe[] | PropertyIndexedKeyframes | null,
+    options?: KeyframeAnimationOptions | number
+  ) {
+    const animation: FakeAnimation = impl
+      ? impl(keyframes, options)
+      : { finish: vi.fn(), cancel: vi.fn(), keyframes, options };
+    animations.push(animation);
+    return animation as unknown as Animation;
+  });
+  Object.defineProperty(HTMLElement.prototype, 'animate', {
+    configurable: true,
+    writable: true,
+    value: spy,
+  });
+  return { animations, spy };
+}
+
+function spyOnAnimate(): { animations: FakeAnimation[]; spy: AnimateMock } {
+  return installAnimate();
+}
+
+function spyOnPositions(map: Record<string, number>) {
+  return vi
+    .spyOn(Element.prototype, 'getBoundingClientRect')
+    .mockImplementation(function (this: Element) {
+      const key = (this as HTMLElement).dataset?.rowKey;
+      const top = key !== undefined && key in map ? map[key] : 0;
+      return {
+        top,
+        left: 0,
+        right: 0,
+        bottom: top,
+        width: 0,
+        height: 0,
+        x: 0,
+        y: top,
+        toJSON: () => ({}),
+      } as DOMRect;
+    });
+}
+
+describe('useFlipRows', () => {
+  afterEach(() => {
+    // installAnimate adds a property that the default vi.restoreAllMocks() does
+    // not undo. Remove it so the next test starts with a clean prototype.
+    if (Object.prototype.hasOwnProperty.call(HTMLElement.prototype, 'animate')) {
+      Reflect.deleteProperty(HTMLElement.prototype, 'animate');
+    }
+  });
+
+  it('does not animate on the initial render', () => {
+    const { spy } = spyOnAnimate();
+    spyOnPositions({ a: 0, b: 30, c: 60 });
+
+    render(<TestTable rows={['a', 'b', 'c']} resetKey="net" />);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('skips when the row signature is unchanged', () => {
+    const { spy } = spyOnAnimate();
+    const rectSpy = spyOnPositions({ a: 0, b: 30, c: 60 });
+
+    const { rerender } = render(<TestTable rows={['a', 'b', 'c']} resetKey="net" />);
+    spy.mockClear();
+    rectSpy.mockClear();
+
+    rerender(<TestTable rows={['a', 'b', 'c']} resetKey="net" />);
+
+    expect(spy).not.toHaveBeenCalled();
+    // Bail-out path: we read row keys but skip measuring on the no-op rerender.
+    expect(rectSpy).not.toHaveBeenCalled();
+  });
+
+  it('plays an enter animation for new rows and FLIP for shifted rows', () => {
+    const { spy, animations } = spyOnAnimate();
+    const rectSpy = spyOnPositions({ a: 0, b: 30, c: 60 });
+
+    const { rerender } = render(<TestTable rows={['a', 'b', 'c']} resetKey="net" />);
+
+    rectSpy.mockImplementation(function (this: Element) {
+      const key = (this as HTMLElement).dataset?.rowKey;
+      const positions: Record<string, number> = { z: 0, a: 30, b: 60, c: 90 };
+      const top = key !== undefined && key in positions ? positions[key] : 0;
+      return {
+        top,
+        left: 0,
+        right: 0,
+        bottom: top,
+        width: 0,
+        height: 0,
+        x: 0,
+        y: top,
+        toJSON: () => ({}),
+      } as DOMRect;
+    });
+
+    rerender(<TestTable rows={['z', 'a', 'b', 'c']} resetKey="net" />);
+
+    // z enters; a, b, c each shifted by 30px -> 4 animations.
+    expect(spy).toHaveBeenCalledTimes(4);
+
+    const enterAnim = animations[0];
+    const enterFrames = enterAnim.keyframes as Keyframe[];
+    expect(enterFrames[0]).toMatchObject({ opacity: 0, transform: 'translateY(-16px)' });
+    expect(enterFrames[1]).toMatchObject({ opacity: 1, transform: 'translateY(0)' });
+
+    const flipAnim = animations[1];
+    const flipFrames = flipAnim.keyframes as Keyframe[];
+    expect(flipFrames[0]).toMatchObject({ transform: 'translateY(-30px)' });
+    expect(flipFrames[1]).toMatchObject({ transform: 'translateY(0)' });
+  });
+
+  it('finishes prior FLIP animations before re-measuring', () => {
+    const { animations } = spyOnAnimate();
+    const rectSpy = spyOnPositions({ a: 0, b: 30, c: 60 });
+
+    const { rerender } = render(<TestTable rows={['a', 'b', 'c']} resetKey="net" />);
+
+    // Trigger a first FLIP pass.
+    rectSpy.mockImplementation(function (this: Element) {
+      const key = (this as HTMLElement).dataset?.rowKey;
+      const positions: Record<string, number> = { z: 0, a: 30, b: 60, c: 90 };
+      const top = key !== undefined && key in positions ? positions[key] : 0;
+      return { top, left: 0, right: 0, bottom: top, width: 0, height: 0, x: 0, y: top, toJSON: () => ({}) } as DOMRect;
+    });
+    rerender(<TestTable rows={['z', 'a', 'b', 'c']} resetKey="net" />);
+
+    const firstPass = [...animations];
+    expect(firstPass.length).toBeGreaterThan(0);
+    firstPass.forEach((a) => expect(a.finish).not.toHaveBeenCalled());
+
+    // Second pass: another new row pushes everyone down again.
+    rectSpy.mockImplementation(function (this: Element) {
+      const key = (this as HTMLElement).dataset?.rowKey;
+      const positions: Record<string, number> = { y: 0, z: 30, a: 60, b: 90, c: 120 };
+      const top = key !== undefined && key in positions ? positions[key] : 0;
+      return { top, left: 0, right: 0, bottom: top, width: 0, height: 0, x: 0, y: top, toJSON: () => ({}) } as DOMRect;
+    });
+    rerender(<TestTable rows={['y', 'z', 'a', 'b', 'c']} resetKey="net" />);
+
+    // All prior animations were finished before the new measurement.
+    firstPass.forEach((a) => expect(a.finish).toHaveBeenCalledTimes(1));
+  });
+
+  it('cancels prior animations and skips animating when resetKey changes', () => {
+    const { animations, spy } = spyOnAnimate();
+    const rectSpy = spyOnPositions({ a: 0, b: 30, c: 60 });
+
+    const { rerender } = render(<TestTable rows={['a', 'b', 'c']} resetKey="net-1" />);
+
+    rectSpy.mockImplementation(function (this: Element) {
+      const key = (this as HTMLElement).dataset?.rowKey;
+      const positions: Record<string, number> = { z: 0, a: 30, b: 60, c: 90 };
+      const top = key !== undefined && key in positions ? positions[key] : 0;
+      return { top, left: 0, right: 0, bottom: top, width: 0, height: 0, x: 0, y: top, toJSON: () => ({}) } as DOMRect;
+    });
+    rerender(<TestTable rows={['z', 'a', 'b', 'c']} resetKey="net-1" />);
+
+    const beforeReset = [...animations];
+    expect(beforeReset.length).toBeGreaterThan(0);
+    spy.mockClear();
+
+    // Network change: completely different data set.
+    rectSpy.mockImplementation(function (this: Element) {
+      const key = (this as HTMLElement).dataset?.rowKey;
+      const positions: Record<string, number> = { x: 0, y: 30 };
+      const top = key !== undefined && key in positions ? positions[key] : 0;
+      return { top, left: 0, right: 0, bottom: top, width: 0, height: 0, x: 0, y: top, toJSON: () => ({}) } as DOMRect;
+    });
+    rerender(<TestTable rows={['x', 'y']} resetKey="net-2" />);
+
+    // Prior animations were cancelled, no new animations played on the reset render.
+    beforeReset.forEach((a) => expect(a.cancel).toHaveBeenCalledTimes(1));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not animate when prefers-reduced-motion is set', () => {
+    const matchMedia = vi.fn().mockReturnValue({ matches: true });
+    vi.stubGlobal('matchMedia', matchMedia);
+    const { spy } = spyOnAnimate();
+    const rectSpy = spyOnPositions({ a: 0, b: 30 });
+
+    const { rerender } = render(<TestTable rows={['a', 'b']} resetKey="net" />);
+
+    rectSpy.mockImplementation(function (this: Element) {
+      const key = (this as HTMLElement).dataset?.rowKey;
+      const positions: Record<string, number> = { c: 0, a: 30, b: 60 };
+      const top = key !== undefined && key in positions ? positions[key] : 0;
+      return { top, left: 0, right: 0, bottom: top, width: 0, height: 0, x: 0, y: top, toJSON: () => ({}) } as DOMRect;
+    });
+    rerender(<TestTable rows={['c', 'a', 'b']} resetKey="net" />);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the tbody ref is not attached', () => {
+    const { spy } = spyOnAnimate();
+    expect(() => {
+      render(<TestTable rows={['a']} resetKey="net" mountTbody={false} />);
+    }).not.toThrow();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('skips FLIP animations for rows whose position did not change meaningfully', () => {
+    const { spy } = spyOnAnimate();
+    spyOnPositions({ a: 0, b: 30 });
+
+    const { rerender } = render(<TestTable rows={['a', 'b']} resetKey="net" />);
+    spy.mockClear();
+    // Order swap with no positional change (same mocked rects) -> no animations.
+    rerender(<TestTable rows={['b', 'a']} resetKey="net" />);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('swallows errors from finish() and cancel() in the underlying Animation', () => {
+    const { animations } = installAnimate((keyframes, options) => ({
+      finish: vi.fn(() => {
+        throw new Error('boom');
+      }),
+      cancel: vi.fn(() => {
+        throw new Error('boom');
+      }),
+      keyframes,
+      options,
+    }));
+    const rectSpy = spyOnPositions({ a: 0, b: 30 });
+
+    const { rerender } = render(<TestTable rows={['a', 'b']} resetKey="net" />);
+
+    rectSpy.mockImplementation(function (this: Element) {
+      const key = (this as HTMLElement).dataset?.rowKey;
+      const positions: Record<string, number> = { c: 0, a: 30, b: 60 };
+      const top = key !== undefined && key in positions ? positions[key] : 0;
+      return { top, left: 0, right: 0, bottom: top, width: 0, height: 0, x: 0, y: top, toJSON: () => ({}) } as DOMRect;
+    });
+
+    // First FLIP pass: produces animations whose finish() throws.
+    rerender(<TestTable rows={['c', 'a', 'b']} resetKey="net" />);
+    expect(animations.length).toBeGreaterThan(0);
+
+    rectSpy.mockImplementation(function (this: Element) {
+      const key = (this as HTMLElement).dataset?.rowKey;
+      const positions: Record<string, number> = { d: 0, c: 30, a: 60, b: 90 };
+      const top = key !== undefined && key in positions ? positions[key] : 0;
+      return { top, left: 0, right: 0, bottom: top, width: 0, height: 0, x: 0, y: top, toJSON: () => ({}) } as DOMRect;
+    });
+
+    // Second pass: prior finish() throws are swallowed.
+    expect(() => {
+      rerender(<TestTable rows={['d', 'c', 'a', 'b']} resetKey="net" />);
+    }).not.toThrow();
+
+    // resetKey change: cancel() throws are also swallowed.
+    expect(() => {
+      rerender(<TestTable rows={['d', 'c', 'a', 'b']} resetKey="net-2" />);
+    }).not.toThrow();
+  });
+});

--- a/src/hooks/useFlipRows.ts
+++ b/src/hooks/useFlipRows.ts
@@ -10,74 +10,129 @@ function prefersReducedMotion(): boolean {
   return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
+function safeFinish(animation: Animation): void {
+  try {
+    animation.finish();
+  } catch {
+    // finish() can throw if the animation has no finite end (not our case),
+    // or if the implementation is incomplete (e.g. jsdom). Either way, ignore.
+  }
+}
+
+function safeCancel(animation: Animation): void {
+  try {
+    animation.cancel();
+  } catch {
+    // See safeFinish.
+  }
+}
+
 /**
  * Animate table rows when their order or membership changes.
  *
- * Tag each `<tr>` with a stable `data-row-key` attribute. After each render the
- * hook captures row positions; on the next render it FLIP-animates surviving
- * rows from their previous position to the new one and fade-slides any rows
- * whose key is new.
+ * Tag each `<tr>` with a stable `data-row-key` attribute. The hook compares
+ * the current row order/identity to the previous render; when it changes,
+ * it FLIP-animates surviving rows from their previous position to the new one
+ * and fade-slides any rows whose key is new.
  *
- * The first commit (and the first commit after `resetKey` changes) only
- * captures positions — no animation plays — so switching networks or
- * initial data loads do not trigger a stampede.
+ * Important: live tables in this app re-render on every websocket tick (they
+ * consume the `latestEvents` context), not just when their own row set
+ * changes. We therefore:
+ *   1. Gate on a row-key signature, so unrelated re-renders are no-ops; and
+ *   2. Finish any FLIP animations we previously started before re-measuring,
+ *      so `getBoundingClientRect()` returns clean layout positions instead of
+ *      animated visual ones (which would compound and drift rows off-screen).
+ *
+ * The first commit and the first commit after `resetKey` changes capture
+ * positions without animating, so initial loads and network switches don't
+ * trigger a stampede.
  */
 export function useFlipRows(
   tbodyRef: React.RefObject<HTMLTableSectionElement | null>,
   resetKey: unknown
 ): void {
   const prevPositionsRef = React.useRef<Map<string, number> | null>(null);
+  const prevSignatureRef = React.useRef<string | null>(null);
   const prevResetKeyRef = React.useRef(resetKey);
+  const activeAnimationsRef = React.useRef<Animation[]>([]);
 
   React.useLayoutEffect(() => {
     if (prevResetKeyRef.current !== resetKey) {
       prevResetKeyRef.current = resetKey;
       prevPositionsRef.current = null;
+      prevSignatureRef.current = null;
+      activeAnimationsRef.current.forEach(safeCancel);
+      activeAnimationsRef.current = [];
     }
 
     const tbody = tbodyRef.current;
     if (!tbody) return;
 
+    const rows = Array.from(
+      tbody.querySelectorAll<HTMLTableRowElement>('tr[data-row-key]')
+    );
+    const signature = rows.map((row) => row.dataset.rowKey ?? '').join('|');
+
+    // Bail out when the row order/identity is unchanged. Tables in this app
+    // re-render on every `latestEvents` context update; without this gate we
+    // would re-measure (and re-baseline) during in-flight animations on every
+    // websocket tick, causing transforms to compound off-screen.
+    if (signature === prevSignatureRef.current) return;
+
+    // Finish FLIP animations from a previous pass so `getBoundingClientRect()`
+    // reflects each row's layout position, not its mid-animation visual one.
+    activeAnimationsRef.current.forEach(safeFinish);
+    activeAnimationsRef.current = [];
+
     const newPositions = new Map<string, number>();
-    tbody.querySelectorAll<HTMLTableRowElement>('tr[data-row-key]').forEach((row) => {
+    rows.forEach((row) => {
       const key = row.dataset.rowKey;
       if (key) newPositions.set(key, row.getBoundingClientRect().top);
     });
 
     const prevPositions = prevPositionsRef.current;
     prevPositionsRef.current = newPositions;
+    prevSignatureRef.current = signature;
 
     if (!prevPositions) return;
     if (prefersReducedMotion()) return;
 
-    newPositions.forEach((newTop, key) => {
-      const row = tbody.querySelector<HTMLTableRowElement>(
-        `tr[data-row-key="${CSS.escape(key)}"]`
-      );
-      if (!row || typeof row.animate !== 'function') return;
+    const nextAnimations: Animation[] = [];
+    rows.forEach((row) => {
+      const key = row.dataset.rowKey;
+      if (!key || typeof row.animate !== 'function') return;
+
+      const newTop = newPositions.get(key);
+      if (newTop === undefined) return;
 
       const oldTop = prevPositions.get(key);
       if (oldTop === undefined) {
-        row.animate(
-          [
-            { opacity: 0, transform: 'translateY(-16px)' },
-            { opacity: 1, transform: 'translateY(0)' },
-          ],
-          { duration: ANIMATION_DURATION, easing: ANIMATION_EASING, fill: 'backwards' }
+        nextAnimations.push(
+          row.animate(
+            [
+              { opacity: 0, transform: 'translateY(-16px)' },
+              { opacity: 1, transform: 'translateY(0)' },
+            ],
+            { duration: ANIMATION_DURATION, easing: ANIMATION_EASING, fill: 'backwards' }
+          )
         );
         return;
       }
 
       const delta = oldTop - newTop;
       if (Math.abs(delta) > 0.5) {
-        row.animate(
-          [
-            { transform: `translateY(${delta}px)` },
-            { transform: 'translateY(0)' },
-          ],
-          { duration: ANIMATION_DURATION, easing: ANIMATION_EASING }
+        nextAnimations.push(
+          row.animate(
+            [
+              { transform: `translateY(${delta}px)` },
+              { transform: 'translateY(0)' },
+            ],
+            { duration: ANIMATION_DURATION, easing: ANIMATION_EASING }
+          )
         );
       }
     });
+
+    activeAnimationsRef.current = nextAnimations;
   });
 }

--- a/src/hooks/useFlipRows.ts
+++ b/src/hooks/useFlipRows.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import React from 'react';
+
+const ANIMATION_DURATION = 450;
+const ANIMATION_EASING = 'cubic-bezier(0.16, 1, 0.3, 1)';
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * Animate table rows when their order or membership changes.
+ *
+ * Tag each `<tr>` with a stable `data-row-key` attribute. After each render the
+ * hook captures row positions; on the next render it FLIP-animates surviving
+ * rows from their previous position to the new one and fade-slides any rows
+ * whose key is new.
+ *
+ * The first commit (and the first commit after `resetKey` changes) only
+ * captures positions — no animation plays — so switching networks or
+ * initial data loads do not trigger a stampede.
+ */
+export function useFlipRows(
+  tbodyRef: React.RefObject<HTMLTableSectionElement | null>,
+  resetKey: unknown
+): void {
+  const prevPositionsRef = React.useRef<Map<string, number> | null>(null);
+  const prevResetKeyRef = React.useRef(resetKey);
+
+  React.useLayoutEffect(() => {
+    if (prevResetKeyRef.current !== resetKey) {
+      prevResetKeyRef.current = resetKey;
+      prevPositionsRef.current = null;
+    }
+
+    const tbody = tbodyRef.current;
+    if (!tbody) return;
+
+    const newPositions = new Map<string, number>();
+    tbody.querySelectorAll<HTMLTableRowElement>('tr[data-row-key]').forEach((row) => {
+      const key = row.dataset.rowKey;
+      if (key) newPositions.set(key, row.getBoundingClientRect().top);
+    });
+
+    const prevPositions = prevPositionsRef.current;
+    prevPositionsRef.current = newPositions;
+
+    if (!prevPositions) return;
+    if (prefersReducedMotion()) return;
+
+    newPositions.forEach((newTop, key) => {
+      const row = tbody.querySelector<HTMLTableRowElement>(
+        `tr[data-row-key="${CSS.escape(key)}"]`
+      );
+      if (!row || typeof row.animate !== 'function') return;
+
+      const oldTop = prevPositions.get(key);
+      if (oldTop === undefined) {
+        row.animate(
+          [
+            { opacity: 0, transform: 'translateY(-16px)' },
+            { opacity: 1, transform: 'translateY(0)' },
+          ],
+          { duration: ANIMATION_DURATION, easing: ANIMATION_EASING, fill: 'backwards' }
+        );
+        return;
+      }
+
+      const delta = oldTop - newTop;
+      if (Math.abs(delta) > 0.5) {
+        row.animate(
+          [
+            { transform: `translateY(${delta}px)` },
+            { transform: 'translateY(0)' },
+          ],
+          { duration: ANIMATION_DURATION, easing: ANIMATION_EASING }
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- New shared `useFlipRows` hook drives a FLIP-style animation for live-updating tables: surviving rows animate from their previous position to the new one (push-down/push-up), and newly inserted rows fade and slide in from above.
- Applied to all three live tables: `LatestBlocksTable`, `MempoolTable`, `TopUsersTable`.
- Honors `prefers-reduced-motion` and suppresses animation across network switches / initial loads via a `resetKey`.

## How it works
- Tag each `<tr>` with a stable `data-row-key` and pass the `<tbody>` ref + a reset key (network) to the hook.
- The hook captures row positions in `useLayoutEffect` and, on the next render, uses the Web Animations API to animate each row from its old `top` to its new `top`.
- Rows whose key is new get an entrance animation (opacity 0→1, translateY(-16px)→0).
- Initial mount and `resetKey` changes capture positions without animating, so switching networks doesn't trigger a stampede.

## Test plan
- [ ] Watch the Latest Blocks table while a new block arrives — top row fades in, others slide down (including the expanded blob-details row).
- [ ] Watch the Mempool table — added txs slide in at the top; when a tx is mined and removed, rows below it slide up.
- [ ] Watch the Top Users table — when user counts change order, rows smoothly swap positions; new users fade in.
- [ ] Switch networks — no flurry of animations on the new data.
- [ ] With OS "Reduce motion" enabled, no animations play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)