### PR TITLE
perf: stop re-rendering all WebSocket consumers on every message

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useCallback, useSyncExternalStore } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useSyncExternalStore } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import SearchModal from './SearchModal';
@@ -21,23 +21,34 @@ const LIVE_STATUS_STYLES: Record<BlobWebSocketConnectionState, { label: string; 
 };
 
 interface LiveStatusIndicatorProps {
-  connectionState: BlobWebSocketConnectionState;
-  activitySequence: number;
   className?: string;
   labelClassName: string;
 }
 
+const PULSE_DURATION_MS = 800;
+
 function LiveStatusIndicator({
-  connectionState,
-  activitySequence,
   className,
   labelClassName,
 }: LiveStatusIndicatorProps) {
+  const { connectionState, subscribe } = useBlobWebSocket();
+  const [pulseKey, setPulseKey] = useState(0);
+  const lastPulseRef = useRef(0);
+
+  useEffect(() => {
+    return subscribe(() => {
+      const now = Date.now();
+      if (now - lastPulseRef.current < PULSE_DURATION_MS) return;
+      lastPulseRef.current = now;
+      setPulseKey((current) => current + 1);
+    });
+  }, [subscribe]);
+
   const liveStatus = LIVE_STATUS_STYLES[connectionState];
   const containerClassName = className
     ? `flex items-center space-x-2 ${className}`
     : 'flex items-center space-x-2';
-  const shouldPulse = connectionState === 'connected' && activitySequence > 0;
+  const shouldPulse = connectionState === 'connected' && pulseKey > 0;
 
   return (
     <div className={containerClassName}>
@@ -45,7 +56,7 @@ function LiveStatusIndicator({
         <div className={`h-2.5 w-2.5 rounded-full ${liveStatus.color}`}></div>
         {shouldPulse && (
           <div
-            key={activitySequence}
+            key={pulseKey}
             className={`absolute inset-0 rounded-full ${liveStatus.color} animate-[live-activity-pulse_800ms_ease-out_forwards]`}
           ></div>
         )}
@@ -58,7 +69,6 @@ function LiveStatusIndicator({
 export default function Header() {
   const { selectedNetwork, setSelectedNetwork, networkOptions } = useNetwork();
   const { timeRange: selectedTimeRange, setTimeRange: setSelectedTimeRange } = useTimeRange();
-  const { connectionState, activitySequence } = useBlobWebSocket();
   const isMounted = useSyncExternalStore(() => () => {}, () => true, () => false);
   const [isNetworkDropdownOpen, setIsNetworkDropdownOpen] = useState(false);
   const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
@@ -191,8 +201,6 @@ export default function Header() {
 
               {/* Connection Status */}
               <LiveStatusIndicator
-                connectionState={connectionState}
-                activitySequence={activitySequence}
                 className="mr-4 ml-1"
                 labelClassName="text-sm text-bodyText"
               />
@@ -380,8 +388,6 @@ export default function Header() {
               <div className="flex items-center gap-3">
                 <i className="fa-regular fa-signal-stream text-blue" aria-hidden="true"></i>
                 <LiveStatusIndicator
-                  connectionState={connectionState}
-                  activitySequence={activitySequence}
                   labelClassName="text-base text-bodyText"
                 />
               </div>

--- a/src/components/LatestBlocksTable.tsx
+++ b/src/components/LatestBlocksTable.tsx
@@ -19,7 +19,7 @@ import {
   getAttributionInitial,
   truncateAddress,
 } from '../utils';
-import { useBlobWebSocket } from '../contexts/LiveDataContext';
+import { useLatestBlobEvent } from '../contexts/LiveDataContext';
 import { transformNewBlockData } from '../lib/api/blocks';
 import { formatRelativeTime } from '../lib/api/core';
 import { DASHBOARD_LATEST_BLOB_LIMIT, LATEST_BLOCK_ROWS } from '../constants';
@@ -299,7 +299,7 @@ function BlobDetailsRow({ block }: { block: Block }) {
 
 export default function LatestBlocksTable() {
   const { selectedNetwork } = useNetwork();
-  const { latestEvents } = useBlobWebSocket();
+  const liveBlockEvent = useLatestBlobEvent('new_block');
   const [expandedBlockId, setExpandedBlockId] = React.useState<number | null>(null);
   const hasUserSelectedBlockRef = React.useRef(false);
 
@@ -309,18 +309,18 @@ export default function LatestBlocksTable() {
     selectedNetwork.apiParam
   );
   const displayData = React.useMemo<LatestBlocksResponse | undefined>(() => {
-    if (!latestEvents.new_block) {
+    if (!liveBlockEvent) {
       return data ? { data: data.data.slice(0, LATEST_BLOCK_ROWS) } : undefined;
     }
 
-    const liveBlock = transformNewBlockData(latestEvents.new_block.data);
+    const liveBlock = transformNewBlockData(liveBlockEvent.data);
     return {
       data: [
         liveBlock,
         ...(data?.data || []).filter((block) => block.number !== liveBlock.number),
       ].slice(0, LATEST_BLOCK_ROWS),
     };
-  }, [data, latestEvents.new_block]);
+  }, [data, liveBlockEvent]);
 
   const toggleBlock = React.useCallback((blockId: number) => {
     hasUserSelectedBlockRef.current = true;

--- a/src/components/LiveMetrics.tsx
+++ b/src/components/LiveMetrics.tsx
@@ -10,7 +10,7 @@ import { BackendStatsWindowsResponse, RollingWindowDataPoint, StatsResponse } fr
 import DataStateWrapper from './DataStateWrapper';
 import { useNetwork } from '../hooks/useNetwork';
 import { useTimeRange } from '../contexts/TimeRangeContext';
-import { useBlobWebSocket } from '../contexts/LiveDataContext';
+import { useLatestBlobEvent } from '../contexts/LiveDataContext';
 
 function formatCompactNumber(value: number): string {
   return new Intl.NumberFormat('en-US', {
@@ -35,7 +35,7 @@ function formatEth(value: number): string {
 export default function LiveMetrics() {
   const { selectedNetwork } = useNetwork();
   const { timeRange } = useTimeRange();
-  const { latestEvents } = useBlobWebSocket();
+  const statsUpdateEvent = useLatestBlobEvent('stats_update');
   const network = selectedNetwork.apiParam;
 
   const fetchStats = useCallback(
@@ -70,8 +70,8 @@ export default function LiveMetrics() {
     [rollingWindows, timeRange]
   );
 
-  const liveStatsData = latestEvents.stats_update
-    ? transformStatsResponse(latestEvents.stats_update.data)
+  const liveStatsData = statsUpdateEvent
+    ? transformStatsResponse(statsUpdateEvent.data)
     : undefined;
   const displayData = liveStatsData || data;
 

--- a/src/components/MempoolTable.test.tsx
+++ b/src/components/MempoolTable.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { DEFAULT_NETWORK } from '../constants';
-import { useBlobWebSocket } from '../contexts/LiveDataContext';
+import { useLatestBlobEvent } from '../contexts/LiveDataContext';
 import { useApiData } from '../hooks/useApiData';
 import { useNetwork } from '../hooks/useNetwork';
 import { transformBlobToMempoolTransaction } from '../lib/api/mempool';
@@ -17,7 +17,7 @@ vi.mock('../hooks/useNetwork', () => ({
 }));
 
 vi.mock('../contexts/LiveDataContext', () => ({
-  useBlobWebSocket: vi.fn(),
+  useLatestBlobEvent: vi.fn(),
 }));
 
 const blob: BlobResponse = {
@@ -49,12 +49,7 @@ describe('MempoolTable', () => {
       setSelectedNetwork: vi.fn(),
       networkOptions: [DEFAULT_NETWORK],
     });
-    vi.mocked(useBlobWebSocket).mockReturnValue({
-      connectionState: 'disconnected',
-      lastEvent: null,
-      latestEvents: {},
-      subscribe: () => () => {},
-    });
+    vi.mocked(useLatestBlobEvent).mockReturnValue(null);
     vi.mocked(useApiData<MempoolResponse>).mockReturnValue({
       data: {
         data: [transformBlobToMempoolTransaction(blob, 0)],

--- a/src/components/MempoolTable.tsx
+++ b/src/components/MempoolTable.tsx
@@ -13,13 +13,13 @@ import {
   getAttributionImageSrc,
   getAttributionInitial,
 } from '../utils';
-import { useBlobWebSocket } from '../contexts/LiveDataContext';
+import { useLatestBlobEvent } from '../contexts/LiveDataContext';
 import { transformBlobToMempoolTransaction } from '../lib/api/mempool';
 import MempoolBlobDetailsModal from './MempoolBlobDetailsModal';
 
 export default function MempoolTable() {
   const { selectedNetwork } = useNetwork();
-  const { latestEvents } = useBlobWebSocket();
+  const liveEvent = useLatestBlobEvent('mempool_update');
   const [selectedTransaction, setSelectedTransaction] = React.useState<MempoolTransaction | null>(null);
 
   const { data, isLoading, error } = useApiData<MempoolResponse>(
@@ -29,7 +29,6 @@ export default function MempoolTable() {
   );
 
   const displayData = React.useMemo<MempoolResponse | undefined>(() => {
-    const liveEvent = latestEvents.mempool_update;
     if (!liveEvent) {
       return data;
     }
@@ -51,7 +50,7 @@ export default function MempoolTable() {
         .slice(0, 10)
         .map((tx, index) => ({ ...tx, id: index + 1 })),
     };
-  }, [data, latestEvents.mempool_update]);
+  }, [data, liveEvent]);
 
   const loadingComponent = (
     <div className="overflow-x-auto border border-divider rounded-lg">

--- a/src/components/TopUsersTable.tsx
+++ b/src/components/TopUsersTable.tsx
@@ -9,21 +9,21 @@ import { TopUsersResponse, User } from '../types';
 import DataStateWrapper from './DataStateWrapper';
 import { useNetwork } from '../hooks/useNetwork';
 import { getAttributionImageSrc, getAttributionInitial } from '../utils';
-import { useBlobWebSocket } from '../contexts/LiveDataContext';
+import { useLatestBlobEvent } from '../contexts/LiveDataContext';
 import { transformUserResponses } from '../lib/api/users';
 
 export default function TopUsersTable() {
   const router = useRouter();
   const { selectedNetwork } = useNetwork();
-  const { latestEvents } = useBlobWebSocket();
+  const usersUpdateEvent = useLatestBlobEvent('users_update');
 
   const { data, isLoading, error } = useApiData<TopUsersResponse>(
     () => api.getTopUsers(10, selectedNetwork.apiParam),
     undefined,
     selectedNetwork.apiParam
   );
-  const displayData = latestEvents.users_update
-    ? transformUserResponses(latestEvents.users_update.data)
+  const displayData = usersUpdateEvent
+    ? transformUserResponses(usersUpdateEvent.data)
     : data;
 
   useEffect(() => {

--- a/src/contexts/LiveDataContext.tsx
+++ b/src/contexts/LiveDataContext.tsx
@@ -13,7 +13,6 @@ import React, {
 import {
   BlobWebSocketConnectionState,
   BlobWebSocketEventMap,
-  LatestBlobWebSocketEvents,
   LiveBlobWebSocketEvent,
   SubscribableBlobEventType,
 } from '@/types';
@@ -27,8 +26,6 @@ type LiveBlobEventHandler = (event: LiveBlobWebSocketEvent) => void;
 
 interface LiveDataContextValue {
   connectionState: BlobWebSocketConnectionState;
-  lastEvent: LiveBlobWebSocketEvent | null;
-  latestEvents: LatestBlobWebSocketEvents;
   subscribe: (handler: LiveBlobEventHandler) => () => void;
 }
 
@@ -40,8 +37,6 @@ interface LiveDataProviderProps {
 
 const defaultContextValue: LiveDataContextValue = {
   connectionState: 'disconnected',
-  lastEvent: null,
-  latestEvents: {},
   subscribe: () => () => {},
 };
 
@@ -55,8 +50,6 @@ export function LiveDataProvider({
   const handlersRef = useRef(new Set<LiveBlobEventHandler>());
   const [connectionState, setConnectionState] =
     useState<BlobWebSocketConnectionState>('connecting');
-  const [lastEvent, setLastEvent] = useState<LiveBlobWebSocketEvent | null>(null);
-  const [latestEvents, setLatestEvents] = useState<LatestBlobWebSocketEvents>({});
   const subscriptionKey = normalizeSubscriptions(subscriptions).join(',');
   const normalizedSubscriptions = useMemo<SubscribableBlobEventType[]>(() => {
     if (!subscriptionKey) {
@@ -80,11 +73,6 @@ export function LiveDataProvider({
       subscriptions: normalizedSubscriptions,
       onConnectionStateChange: setConnectionState,
       onEvent: (event) => {
-        setLastEvent(event);
-        setLatestEvents((currentEvents) => ({
-          ...currentEvents,
-          [event.type]: event,
-        }));
         handlersRef.current.forEach((handler) => {
           handler(event);
         });
@@ -106,11 +94,9 @@ export function LiveDataProvider({
   const value = useMemo<LiveDataContextValue>(
     () => ({
       connectionState,
-      lastEvent,
-      latestEvents,
       subscribe,
     }),
-    [connectionState, lastEvent, latestEvents, subscribe]
+    [connectionState, subscribe]
   );
 
   return <LiveDataContext.Provider value={value}>{children}</LiveDataContext.Provider>;
@@ -138,6 +124,14 @@ export function useLiveBlobEvent<EventType extends SubscribableBlobEventType>(
       }
     });
   }, [eventType, subscribe]);
+}
+
+export function useLatestBlobEvent<EventType extends SubscribableBlobEventType>(
+  eventType: EventType
+): BlobWebSocketEventMap[EventType] | null {
+  const [event, setEvent] = useState<BlobWebSocketEventMap[EventType] | null>(null);
+  useLiveBlobEvent(eventType, setEvent);
+  return event;
 }
 
 function normalizeSubscriptions(subscriptions: SubscribableBlobEventType[]) {

--- a/src/contexts/LiveDataContext.tsx
+++ b/src/contexts/LiveDataContext.tsx
@@ -27,7 +27,6 @@ type LiveBlobEventHandler = (event: LiveBlobWebSocketEvent) => void;
 
 interface LiveDataContextValue {
   connectionState: BlobWebSocketConnectionState;
-  activitySequence: number;
   lastEvent: LiveBlobWebSocketEvent | null;
   latestEvents: LatestBlobWebSocketEvents;
   subscribe: (handler: LiveBlobEventHandler) => () => void;
@@ -41,7 +40,6 @@ interface LiveDataProviderProps {
 
 const defaultContextValue: LiveDataContextValue = {
   connectionState: 'disconnected',
-  activitySequence: 0,
   lastEvent: null,
   latestEvents: {},
   subscribe: () => () => {},
@@ -57,7 +55,6 @@ export function LiveDataProvider({
   const handlersRef = useRef(new Set<LiveBlobEventHandler>());
   const [connectionState, setConnectionState] =
     useState<BlobWebSocketConnectionState>('connecting');
-  const [activitySequence, setActivitySequence] = useState(0);
   const [lastEvent, setLastEvent] = useState<LiveBlobWebSocketEvent | null>(null);
   const [latestEvents, setLatestEvents] = useState<LatestBlobWebSocketEvents>({});
   const subscriptionKey = normalizeSubscriptions(subscriptions).join(',');
@@ -82,9 +79,6 @@ export function LiveDataProvider({
       url: buildBlobWebSocketUrl(network),
       subscriptions: normalizedSubscriptions,
       onConnectionStateChange: setConnectionState,
-      onActivity: () => {
-        setActivitySequence((currentSequence) => currentSequence + 1);
-      },
       onEvent: (event) => {
         setLastEvent(event);
         setLatestEvents((currentEvents) => ({
@@ -112,12 +106,11 @@ export function LiveDataProvider({
   const value = useMemo<LiveDataContextValue>(
     () => ({
       connectionState,
-      activitySequence,
       lastEvent,
       latestEvents,
       subscribe,
     }),
-    [activitySequence, connectionState, lastEvent, latestEvents, subscribe]
+    [connectionState, lastEvent, latestEvents, subscribe]
   );
 
   return <LiveDataContext.Provider value={value}>{children}</LiveDataContext.Provider>;


### PR DESCRIPTION
## Summary

- `LiveDataContext`'s `activitySequence` was incremented on every WebSocket message and included in the memoized context value, recreating the context object on every event. This forced every `useBlobWebSocket()` consumer — Header, MempoolTable, LatestBlocksTable, LiveMetrics, TopUsersTable, BlobMarketPanels — to re-render on each message. On busy networks (frequent `mempool_update` events) this produced hundreds of subtree renders per second plus animation div unmount/remount churn from `key={activitySequence}`, leading to the browser killing tabs left open for a few minutes.
- Removed `activitySequence` (and the corresponding `onActivity` wiring) from the shared context. `LiveStatusIndicator` is now self-contained: it subscribes to events directly and drives its own local pulse state, throttled to one animation restart per 800ms (the pulse duration). Sustained activity yields a continuous pulse without thrashing.
- The rest of the `Header` no longer consumes `useBlobWebSocket()` at all, so it no longer re-renders on WebSocket activity. Tables/metrics still update when their own event type arrives (necessary), but not on unrelated events.

## Why

Symptom: Chrome was killing the tab after a few minutes on networks with significant mempool activity. Profiling pointed to the re-render storm triggered by the per-message `activitySequence` bump.

## Test plan

- [ ] `npm run dev` — confirm the live status indicator pulses while events stream in (and stops/quiets on idle/disconnect)
- [ ] Leave a tab open on a busy network for 10+ minutes — memory should stabilize rather than grow until the tab is killed
- [ ] Mempool / Latest Blocks / Live Metrics tables still update in real time when their respective events arrive
- [ ] `npm run lint` and `npm run build` pass (pre-existing unrelated lint/type errors aside)

🤖 Generated with [Claude Code](https://claude.com/claude-code)