### PR TITLE
fix: stop search modal from thrashing listeners on websocket activity

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -80,10 +80,12 @@ export default function Header() {
 
   const toggleSearchModal = useCallback(() => {
     setIsSearchModalOpen(prev => !prev);
-    if (isMobileMenuOpen) {
-      setIsMobileMenuOpen(false);
-    }
-  }, [isMobileMenuOpen]);
+    setIsMobileMenuOpen(false);
+  }, []);
+
+  const closeSearchModal = useCallback(() => {
+    setIsSearchModalOpen(false);
+  }, []);
 
   // Close mobile menu when clicking outside
   // Remove the existing click outside handler as it may be interfering
@@ -435,7 +437,7 @@ export default function Header() {
       {/* Search Modal */}
       <SearchModal
         isOpen={isSearchModalOpen}
-        onClose={() => setIsSearchModalOpen(false)}
+        onClose={closeSearchModal}
       />
     </>
   );

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useRef, FormEvent } from 'react';
+import React, { memo, useState, useEffect, useRef, FormEvent } from 'react';
 import useScrollLock from '../hooks/useScrollLock';
 
 interface SearchModalProps {
@@ -10,24 +10,24 @@ interface SearchModalProps {
 
 type SearchType = 'blocks' | 'blobs' | 'transactions' | 'rollups' | null;
 
-export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
+function SearchModal({ isOpen, onClose }: SearchModalProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedType, setSelectedType] = useState<SearchType>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
-  
+
   // Lock scrolling when the modal is open
   useScrollLock(isOpen);
 
   // Reset search query and selected type when modal opens, then focus input
   useEffect(() => {
-    if (isOpen) {
-      setTimeout(() => {
-        setSearchQuery('');
-        setSelectedType(null);
-        searchInputRef.current?.focus();
-      }, 100);
-    }
+    if (!isOpen) return;
+    const timer = setTimeout(() => {
+      setSearchQuery('');
+      setSelectedType(null);
+      searchInputRef.current?.focus();
+    }, 100);
+    return () => clearTimeout(timer);
   }, [isOpen]);
 
   // Close modal when clicking outside
@@ -217,3 +217,5 @@ export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
     </div>
   );
 }
+
+export default memo(SearchModal);


### PR DESCRIPTION
## Summary

Clicking the search bar could make the site feel unresponsive. The header re-renders on every blob websocket activity event (frequent on mainnet), and was passing a fresh `onClose` arrow function to `SearchModal` each render. That caused `SearchModal`'s click-outside and keydown `useEffect`s to detach and reattach document listeners many times per second — combined with the modal re-rendering and a leaked focus `setTimeout`, this could starve the main thread.

- Memoize `closeSearchModal` and drop `isMobileMenuOpen` from `toggleSearchModal`'s deps so the callbacks stay stable across renders.
- Wrap `SearchModal` in `React.memo` so it skips re-renders driven by unrelated `Header` updates.
- Clear the focus-on-open `setTimeout` in its effect cleanup.

## Test plan

- [ ] Open the dashboard, click the search bar — modal opens, input is focused, page stays responsive.
- [ ] Type in the input — characters appear without lag while blob activity continues in the background.
- [ ] Press Esc / click outside — modal closes cleanly, body scroll restored.
- [ ] Press `/` shortcut — modal opens.
- [ ] Open the mobile menu, then tap Search — search modal opens and mobile menu closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)