### PR TITLE
feat: compact Recent Block Fees + /blocks page with pagination

### DIFF
--- a/src/app/blocks/page.tsx
+++ b/src/app/blocks/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import Link from 'next/link';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+import LatestBlocksTable from '@/components/LatestBlocksTable';
+
+export default function BlocksPage() {
+  return (
+    <main className="min-h-screen bg-background bg-grid-pattern bg-grid-size">
+      <Header />
+      <div className="container mx-auto px-4 py-8 max-w-7xl">
+        <Link
+          href="/"
+          className="text-blue hover:underline text-sm mb-6 inline-flex items-center gap-2"
+        >
+          <i className="fa-regular fa-arrow-left" aria-hidden="true" />
+          Back to Dashboard
+        </Link>
+
+        <section>
+          <h1 className="text-3xl font-windsor-bold text-white mb-2">
+            Latest Blocks &amp; Blob Fees
+          </h1>
+          <p className="text-sm text-bodyText mb-6">
+            Browse recent blocks with blob counts, fees, and per-blob details. Click any row to
+            expand its blob breakdown.
+          </p>
+          <LatestBlocksTable />
+        </section>
+      </div>
+      <Footer />
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import Header from '@/components/Header';
 import LiveMetrics from '@/components/LiveMetrics';
 import BlobMarketPanels from '@/components/BlobMarketPanels';
 import MetricsCharts from '@/components/MetricsCharts';
-import LatestBlocksTable from '@/components/LatestBlocksTable';
+import RecentBlocksPanel from '@/components/RecentBlocksPanel';
 import TopUsersTable from '@/components/TopUsersTable';
 import MempoolTable from '@/components/MempoolTable';
 import ExplainerSection from '@/components/ExplainerSection';
@@ -16,8 +16,9 @@ export default function Home() {
     <main className="min-h-screen bg-background bg-grid-pattern bg-grid-size">
       <Header />
       <div className="container mx-auto px-4 py-8 max-w-7xl">
-        <div className="mb-12">
-          <LatestBlocksTable />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-start mb-12">
+          <RecentBlocksPanel />
+          <MetricsCharts />
         </div>
 
         <div className="mb-12">
@@ -39,9 +40,6 @@ export default function Home() {
           </div>
 
           <div className="lg:col-span-2 space-y-8">
-            <div className="mb-12">
-              <MetricsCharts />
-            </div>
             <div className="mb-12 pt-2">
               <h2 className="text-2xl font-windsor-bold text-white mb-3">What are blobs?</h2>
               <ExplainerSection />

--- a/src/components/BlobDetailsContent.tsx
+++ b/src/components/BlobDetailsContent.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import React from 'react';
+import Image from 'next/image';
+import { Block, BlobResponse } from '../types';
+import {
+  formatBlobFee,
+  formatBlobSize,
+  formatBlobTotalCost,
+  formatBlobWeiCost,
+  formatFeeHeadroom,
+  getAttributionImageSrc,
+  getAttributionInitial,
+  truncateAddress,
+} from '../utils';
+import { formatRelativeTime } from '../lib/api/core';
+
+function truncateTxHash(hash: string): string {
+  if (hash.length <= 14) return hash;
+  return `${hash.substring(0, 10)}...${hash.substring(hash.length - 4)}`;
+}
+
+function BlobUserCell({ blob }: { blob: BlobResponse }) {
+  const attribution = blob.user_attribution || 'Unknown';
+  const imageSrc = getAttributionImageSrc(attribution);
+
+  return (
+    <div className="flex items-center min-w-0">
+      {imageSrc ? (
+        <Image
+          src={imageSrc}
+          alt={attribution}
+          width={20}
+          height={20}
+          className="inline-block w-5 h-5 mr-2 shrink-0"
+        />
+      ) : (
+        <span className="inline-flex items-center justify-center w-5 h-5 rounded-full mr-2 bg-gray-500 text-[10px] text-white font-medium shrink-0">
+          {getAttributionInitial(attribution)}
+        </span>
+      )}
+      <span className="truncate">{attribution}</span>
+    </div>
+  );
+}
+
+function BlobDetailField({
+  label,
+  title,
+  children,
+  monospace = false,
+}: {
+  label: string;
+  title?: string;
+  children: React.ReactNode;
+  monospace?: boolean;
+}) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-[11px] font-medium text-[#6e7787] uppercase tracking-wider">{label}</dt>
+      <dd
+        className={`mt-1 text-sm text-white truncate ${monospace ? 'font-mono' : ''}`}
+        title={title}
+      >
+        {children}
+      </dd>
+    </div>
+  );
+}
+
+export function BlobDetailsContent({ block }: { block: Block }) {
+  return (
+    <div className="px-4 sm:px-6 py-4 border-t border-dividerBlue/50">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+        <h3 className="text-sm font-medium text-white">Blob details</h3>
+        <span className="text-xs text-[#6e7787]">
+          {block.blobs.length} blob{block.blobs.length === 1 ? '' : 's'} in block {block.number}
+        </span>
+      </div>
+
+      {block.blobs.length === 0 ? (
+        <div className="mt-4 text-sm text-[#6c727f]">No blob records available for this block.</div>
+      ) : (
+        <div className="mt-3 divide-y divide-divider/80">
+          {block.blobs.map((blob) => {
+            const realizedCost = blob.realized_cost_wei
+              ? formatBlobWeiCost(blob.realized_cost_wei)
+              : formatBlobTotalCost(blob.total_cost_eth);
+            const maxCost = formatBlobWeiCost(blob.max_cost_wei);
+            const baseFee = formatBlobFee(blob.base_fee_per_blob_gas_gwei, blob.base_fee_per_blob_gas);
+            const tip = formatBlobFee(blob.tip_per_blob_gas_gwei, blob.tip_per_blob_gas);
+            const maxFee = formatBlobFee(blob.max_fee_per_blob_gas_gwei, blob.max_fee_per_blob_gas);
+            const headroom = formatFeeHeadroom(blob.fee_cap_headroom_percent);
+
+            return (
+              <div key={`${blob.tx_hash}-${blob.blob_index}`} className="py-3">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                  <div className="text-sm font-mono text-white">Blob #{blob.blob_index}</div>
+                  <BlobUserCell blob={blob} />
+                </div>
+                <dl className="mt-3 grid grid-cols-2 md:grid-cols-4 gap-x-5 gap-y-3">
+                  <BlobDetailField label="Tx Hash" title={blob.tx_hash} monospace>
+                    {blob.transaction_url ? (
+                      <a
+                        href={blob.transaction_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue hover:underline"
+                      >
+                        {truncateTxHash(blob.tx_hash)}
+                      </a>
+                    ) : (
+                      truncateTxHash(blob.tx_hash)
+                    )}
+                  </BlobDetailField>
+                  <BlobDetailField label="From" title={blob.from_address} monospace>
+                    {blob.from_address_url ? (
+                      <a
+                        href={blob.from_address_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue hover:underline"
+                      >
+                        {truncateAddress(blob.from_address)}
+                      </a>
+                    ) : (
+                      truncateAddress(blob.from_address)
+                    )}
+                  </BlobDetailField>
+                  <BlobDetailField label="Size">{formatBlobSize(blob.blob_size_bytes)}</BlobDetailField>
+                  <BlobDetailField label="Cost" title={realizedCost}>
+                    {realizedCost}
+                  </BlobDetailField>
+                  <BlobDetailField label="Max Cost" title={maxCost}>
+                    {maxCost}
+                  </BlobDetailField>
+                  <BlobDetailField label="Base Fee" title={baseFee}>
+                    {baseFee}
+                  </BlobDetailField>
+                  <BlobDetailField label="Tip" title={tip}>
+                    {tip}
+                  </BlobDetailField>
+                  <BlobDetailField label="Max Fee" title={maxFee}>
+                    {maxFee}
+                  </BlobDetailField>
+                  <BlobDetailField label="Headroom">{headroom}</BlobDetailField>
+                  <BlobDetailField label="Time">{formatRelativeTime(blob.timestamp)}</BlobDetailField>
+                  <BlobDetailField label="Status">
+                    {blob.confirmed ? 'Confirmed' : 'Pending'}
+                  </BlobDetailField>
+                </dl>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/BlobMarketPanels.tsx
+++ b/src/components/BlobMarketPanels.tsx
@@ -9,7 +9,6 @@ import { formatGwei, formatNumber, formatPercent } from '@/utils';
 import DataStateWrapper from './DataStateWrapper';
 
 const FALLBACK_REFRESH_MS = 60000;
-const RECENT_BLOCK_ROWS = 8;
 
 export default function BlobMarketPanels() {
   const { selectedNetwork } = useNetwork();
@@ -102,12 +101,7 @@ export default function BlobMarketPanels() {
         error={initialError}
         loadingComponent={<BlobMarketSkeleton />}
       >
-        {pricing && (
-          <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
-            <CurrentMarketPanel pricing={pricing} />
-            <RecentFeeBlocksPanel pricing={pricing} />
-          </div>
-        )}
+        {pricing && <CurrentMarketPanel pricing={pricing} />}
       </DataStateWrapper>
 
       {pricing && error && (
@@ -193,57 +187,6 @@ function CurrentMarketPanel({ pricing }: { pricing: BlobPricing }) {
   );
 }
 
-function RecentFeeBlocksPanel({ pricing }: { pricing: BlobPricing }) {
-  return (
-    <article className="rounded-lg border border-divider bg-[#161a29]/80 p-5">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h3 className="text-lg font-medium text-white">Recent Block Fees</h3>
-          <p className="text-sm text-[#8f9aad]">{pricing.recentBlocks.length} block pricing window</p>
-        </div>
-        <span className="rounded-full border border-[#8f9aad]/40 bg-[#8f9aad]/10 px-3 py-1 text-xs text-[#d7dde8]">
-          {pricing.forkStage}
-        </span>
-      </div>
-
-      <div className="mt-5 space-y-3">
-        {pricing.recentBlocks.slice(0, RECENT_BLOCK_ROWS).map((block) => (
-          <RecentFeeBlockRow key={block.blockNumber} block={block} />
-        ))}
-      </div>
-    </article>
-  );
-}
-
-function RecentFeeBlockRow({ block }: { block: BlobPricingRecentBlock }) {
-  const fillLabel = `${block.blobCount}/${block.maxBlobs}`;
-  const status = block.isFull ? 'Full' : block.isAboveTarget ? 'Above target' : 'Under target';
-
-  return (
-    <div className="grid grid-cols-2 sm:grid-cols-[minmax(5.5rem,0.8fr)_minmax(8rem,1.2fr)_minmax(7rem,1fr)_minmax(5.5rem,0.8fr)] items-center gap-3 rounded-md border border-divider/70 bg-[#111522]/70 px-3 py-2">
-      <div className="min-w-0">
-        <div className="text-[11px] text-[#8f9aad]">Block</div>
-        <div className="truncate text-sm font-medium text-white">{block.blockNumber.toLocaleString()}</div>
-      </div>
-      <div className="min-w-0">
-        <div className="mb-1 flex items-center justify-between gap-2 text-[11px] text-[#8f9aad]">
-          <span>{fillLabel} blobs</span>
-          <span>{formatPercent(block.utilizationPercent, 0)}</span>
-        </div>
-        <FullnessBar percent={block.utilizationPercent} isAboveTarget={block.isAboveTarget} />
-      </div>
-      <div className="min-w-0">
-        <div className="text-[11px] text-[#8f9aad]">Base fee</div>
-        <div className="truncate text-sm font-medium text-white">{block.blobBaseFee}</div>
-      </div>
-      <div className="min-w-0">
-        <div className="text-[11px] text-[#8f9aad]">State</div>
-        <div className="truncate text-sm font-medium text-white">{status}</div>
-      </div>
-    </div>
-  );
-}
-
 function MetricBlock({ label, value, compact = false }: { label: string; value: string; compact?: boolean }) {
   return (
     <div>
@@ -280,17 +223,13 @@ function FullnessBar({ percent, isAboveTarget }: { percent: number; isAboveTarge
 
 function BlobMarketSkeleton() {
   return (
-    <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
-      {[...Array(2)].map((_, index) => (
-        <div key={index} className="animate-pulse rounded-lg border border-divider bg-[#161a29]/80 p-5">
-          <div className="h-6 w-1/3 rounded bg-[#202538] mb-5" />
-          <div className="grid grid-cols-2 gap-5">
-            <div className="h-20 rounded bg-[#202538]" />
-            <div className="h-20 rounded bg-[#202538]" />
-          </div>
-          <div className="mt-5 h-28 rounded bg-[#202538]" />
-        </div>
-      ))}
+    <div className="animate-pulse rounded-lg border border-divider bg-[#161a29]/80 p-5">
+      <div className="h-6 w-1/3 rounded bg-[#202538] mb-5" />
+      <div className="grid grid-cols-2 gap-5">
+        <div className="h-20 rounded bg-[#202538]" />
+        <div className="h-20 rounded bg-[#202538]" />
+      </div>
+      <div className="mt-5 h-28 rounded bg-[#202538]" />
     </div>
   );
 }

--- a/src/components/LatestBlocksTable.tsx
+++ b/src/components/LatestBlocksTable.tsx
@@ -10,27 +10,18 @@ import { useNetwork } from '../hooks/useNetwork';
 import {
   formatBlobFee,
   formatBlobCount,
-  formatBlobSize,
-  formatFeeHeadroom,
-  formatBlobTotalCost,
   formatBlobWeiCost,
   formatUtilizationPercent,
   getAttributionImageSrc,
   getAttributionInitial,
-  truncateAddress,
 } from '../utils';
 import { useBlobWebSocket } from '../contexts/LiveDataContext';
 import { transformNewBlockData } from '../lib/api/blocks';
-import { formatRelativeTime } from '../lib/api/core';
-import { DASHBOARD_LATEST_BLOB_LIMIT, LATEST_BLOCK_ROWS } from '../constants';
+import { BlobDetailsContent } from './BlobDetailsContent';
+import { BLOCKS_PAGE_LIMIT, BLOCKS_PAGE_SIZE } from '../constants';
 
 function getBlockDetailsId(blockId: number): string {
   return `block-${blockId}-blob-details`;
-}
-
-function truncateTxHash(hash: string): string {
-  if (hash.length <= 14) return hash;
-  return `${hash.substring(0, 10)}...${hash.substring(hash.length - 4)}`;
 }
 
 function formatBlockBaseFee(block: Block): string {
@@ -149,149 +140,11 @@ function AttributionDisplay({ attribution }: { attribution: string[] }) {
   );
 }
 
-function BlobUserCell({ blob }: { blob: BlobResponse }) {
-  const attribution = blob.user_attribution || 'Unknown';
-  const imageSrc = getAttributionImageSrc(attribution);
-
-  return (
-    <div className="flex items-center min-w-0">
-      {imageSrc ? (
-        <Image
-          src={imageSrc}
-          alt={attribution}
-          width={20}
-          height={20}
-          className="inline-block w-5 h-5 mr-2 shrink-0"
-        />
-      ) : (
-        <span className="inline-flex items-center justify-center w-5 h-5 rounded-full mr-2 bg-gray-500 text-[10px] text-white font-medium shrink-0">
-          {getAttributionInitial(attribution)}
-        </span>
-      )}
-      <span className="truncate">{attribution}</span>
-    </div>
-  );
-}
-
-function BlobDetailField({
-  label,
-  title,
-  children,
-  monospace = false,
-}: {
-  label: string;
-  title?: string;
-  children: React.ReactNode;
-  monospace?: boolean;
-}) {
-  return (
-    <div className="min-w-0">
-      <dt className="text-[11px] font-medium text-[#6e7787] uppercase tracking-wider">{label}</dt>
-      <dd
-        className={`mt-1 text-sm text-white truncate ${monospace ? 'font-mono' : ''}`}
-        title={title}
-      >
-        {children}
-      </dd>
-    </div>
-  );
-}
-
 function BlobDetailsRow({ block }: { block: Block }) {
   return (
     <tr id={getBlockDetailsId(block.id)} className="bg-[#111522]">
       <td colSpan={6} className="p-0">
-        <div className="px-4 sm:px-6 py-4 border-t border-dividerBlue/50">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-            <h3 className="text-sm font-medium text-white">Blob details</h3>
-            <span className="text-xs text-[#6e7787]">
-              {block.blobs.length} blob{block.blobs.length === 1 ? '' : 's'} in block {block.number}
-            </span>
-          </div>
-
-          {block.blobs.length === 0 ? (
-            <div className="mt-4 text-sm text-[#6c727f]">No blob records available for this block.</div>
-          ) : (
-            <div className="mt-3 divide-y divide-divider/80">
-              {block.blobs.map((blob) => {
-                const realizedCost = blob.realized_cost_wei
-                  ? formatBlobWeiCost(blob.realized_cost_wei)
-                  : formatBlobTotalCost(blob.total_cost_eth);
-                const maxCost = formatBlobWeiCost(blob.max_cost_wei);
-                const baseFee = formatBlobFee(blob.base_fee_per_blob_gas_gwei, blob.base_fee_per_blob_gas);
-                const tip = formatBlobFee(blob.tip_per_blob_gas_gwei, blob.tip_per_blob_gas);
-                const maxFee = formatBlobFee(blob.max_fee_per_blob_gas_gwei, blob.max_fee_per_blob_gas);
-                const headroom = formatFeeHeadroom(blob.fee_cap_headroom_percent);
-
-                return (
-                  <div key={`${blob.tx_hash}-${blob.blob_index}`} className="py-3">
-                    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                      <div className="text-sm font-mono text-white">Blob #{blob.blob_index}</div>
-                      <BlobUserCell blob={blob} />
-                    </div>
-                    <dl className="mt-3 grid grid-cols-2 md:grid-cols-4 gap-x-5 gap-y-3">
-                      <BlobDetailField label="Tx Hash" title={blob.tx_hash} monospace>
-                        {blob.transaction_url ? (
-                          <a
-                            href={blob.transaction_url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-blue hover:underline"
-                          >
-                            {truncateTxHash(blob.tx_hash)}
-                          </a>
-                        ) : (
-                          truncateTxHash(blob.tx_hash)
-                        )}
-                      </BlobDetailField>
-                      <BlobDetailField label="From" title={blob.from_address} monospace>
-                        {blob.from_address_url ? (
-                          <a
-                            href={blob.from_address_url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-blue hover:underline"
-                          >
-                            {truncateAddress(blob.from_address)}
-                          </a>
-                        ) : (
-                          truncateAddress(blob.from_address)
-                        )}
-                      </BlobDetailField>
-                      <BlobDetailField label="Size">
-                        {formatBlobSize(blob.blob_size_bytes)}
-                      </BlobDetailField>
-                      <BlobDetailField label="Cost" title={realizedCost}>
-                        {realizedCost}
-                      </BlobDetailField>
-                      <BlobDetailField label="Max Cost" title={maxCost}>
-                        {maxCost}
-                      </BlobDetailField>
-                      <BlobDetailField label="Base Fee" title={baseFee}>
-                        {baseFee}
-                      </BlobDetailField>
-                      <BlobDetailField label="Tip" title={tip}>
-                        {tip}
-                      </BlobDetailField>
-                      <BlobDetailField label="Max Fee" title={maxFee}>
-                        {maxFee}
-                      </BlobDetailField>
-                      <BlobDetailField label="Headroom">
-                        {headroom}
-                      </BlobDetailField>
-                      <BlobDetailField label="Time">
-                        {formatRelativeTime(blob.timestamp)}
-                      </BlobDetailField>
-                      <BlobDetailField label="Status">
-                        {blob.confirmed ? 'Confirmed' : 'Pending'}
-                      </BlobDetailField>
-                    </dl>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
+        <BlobDetailsContent block={block} />
       </td>
     </tr>
   );
@@ -301,26 +154,32 @@ export default function LatestBlocksTable() {
   const { selectedNetwork } = useNetwork();
   const { latestEvents } = useBlobWebSocket();
   const [expandedBlockId, setExpandedBlockId] = React.useState<number | null>(null);
+  const [page, setPage] = React.useState(1);
   const hasUserSelectedBlockRef = React.useRef(false);
 
   const { data, isLoading, error } = useApiData<LatestBlocksResponse>(
-    () => api.getLatestBlocks(DASHBOARD_LATEST_BLOB_LIMIT, selectedNetwork.apiParam),
+    () => api.getLatestBlocks(BLOCKS_PAGE_LIMIT, selectedNetwork.apiParam),
     undefined,
     selectedNetwork.apiParam
   );
-  const displayData = React.useMemo<LatestBlocksResponse | undefined>(() => {
-    if (!latestEvents.new_block) {
-      return data ? { data: data.data.slice(0, LATEST_BLOCK_ROWS) } : undefined;
-    }
+  const mergedBlocks = React.useMemo<Block[]>(() => {
+    const baseBlocks = data?.data ?? [];
+    if (!latestEvents.new_block) return baseBlocks;
 
     const liveBlock = transformNewBlockData(latestEvents.new_block.data);
-    return {
-      data: [
-        liveBlock,
-        ...(data?.data || []).filter((block) => block.number !== liveBlock.number),
-      ].slice(0, LATEST_BLOCK_ROWS),
-    };
+    return [
+      liveBlock,
+      ...baseBlocks.filter((block) => block.number !== liveBlock.number),
+    ].slice(0, BLOCKS_PAGE_LIMIT);
   }, [data, latestEvents.new_block]);
+
+  const totalPages = Math.max(1, Math.ceil(mergedBlocks.length / BLOCKS_PAGE_SIZE));
+  const safePage = Math.min(page, totalPages);
+  const pageStart = (safePage - 1) * BLOCKS_PAGE_SIZE;
+  const displayData = React.useMemo<LatestBlocksResponse | undefined>(() => {
+    if (!mergedBlocks.length) return undefined;
+    return { data: mergedBlocks.slice(pageStart, pageStart + BLOCKS_PAGE_SIZE) };
+  }, [mergedBlocks, pageStart]);
 
   const toggleBlock = React.useCallback((blockId: number) => {
     hasUserSelectedBlockRef.current = true;
@@ -340,6 +199,7 @@ export default function LatestBlocksTable() {
   React.useEffect(() => {
     hasUserSelectedBlockRef.current = false;
     setExpandedBlockId(null);
+    setPage(1);
   }, [selectedNetwork.apiParam]);
 
   React.useEffect(() => {
@@ -404,10 +264,11 @@ export default function LatestBlocksTable() {
     </div>
   );
 
-  return (
-    <section>
-      <h2 className="text-2xl font-windsor-bold text-white mb-4">Latest Blocks & Blob Fees</h2>
+  const pageRangeStart = mergedBlocks.length === 0 ? 0 : pageStart + 1;
+  const pageRangeEnd = Math.min(pageStart + BLOCKS_PAGE_SIZE, mergedBlocks.length);
 
+  return (
+    <div>
       <DataStateWrapper
         isLoading={isLoading && !displayData}
         error={displayData ? null : error}
@@ -514,6 +375,42 @@ export default function LatestBlocksTable() {
           </div>
         )}
       </DataStateWrapper>
-    </section>
+
+      {displayData && mergedBlocks.length > BLOCKS_PAGE_SIZE && (
+        <div className="mt-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 text-sm text-[#8a93a5]">
+          <div>
+            Showing <span className="text-white">{pageRangeStart}</span>
+            {pageRangeEnd > pageRangeStart && (
+              <>
+                {' '}- <span className="text-white">{pageRangeEnd}</span>
+              </>
+            )}{' '}
+            of <span className="text-white">{mergedBlocks.length}</span> blocks
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={safePage <= 1}
+              className="px-3 py-1 rounded-md border border-divider bg-[#1d1f23] text-white disabled:opacity-40 disabled:cursor-not-allowed hover:bg-[#23252a]"
+            >
+              <i className="fa-regular fa-chevron-left text-xs" aria-hidden="true" /> Prev
+            </button>
+            <span className="px-2">
+              Page <span className="text-white">{safePage}</span> of{' '}
+              <span className="text-white">{totalPages}</span>
+            </span>
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={safePage >= totalPages}
+              className="px-3 py-1 rounded-md border border-divider bg-[#1d1f23] text-white disabled:opacity-40 disabled:cursor-not-allowed hover:bg-[#23252a]"
+            >
+              Next <i className="fa-regular fa-chevron-right text-xs" aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/components/RecentBlocksPanel.tsx
+++ b/src/components/RecentBlocksPanel.tsx
@@ -152,10 +152,20 @@ export default function RecentBlocksPanel() {
 
   const defaultExpandedId =
     displayBlocks.find((block) => block.blobs.length > 0)?.id ?? displayBlocks[0]?.id ?? null;
-  const expandedBlockId =
-    selection.kind === 'explicit' && displayBlocks.some((block) => block.id === selection.blockId)
-      ? selection.blockId
-      : defaultExpandedId;
+
+  let expandedBlockId: number | null;
+  if (selection.kind === 'default') {
+    expandedBlockId = defaultExpandedId;
+  } else if (selection.blockId === null) {
+    // user explicitly collapsed the row — keep it closed
+    expandedBlockId = null;
+  } else if (displayBlocks.some((block) => block.id === selection.blockId)) {
+    expandedBlockId = selection.blockId;
+  } else {
+    // explicit selection points at a block that's no longer visible (e.g. after
+    // a network switch or paged-out block) — fall back to the default
+    expandedBlockId = defaultExpandedId;
+  }
 
   const toggleBlock = React.useCallback((blockId: number) => {
     setSelection((current) => {
@@ -168,6 +178,12 @@ export default function RecentBlocksPanel() {
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>, blockId: number) => {
+      // Only treat Enter/Space as a row toggle when the row itself is the
+      // event target. Without this, pressing Enter/Space while focused on a
+      // nested interactive element (e.g. the block-number link) bubbles up
+      // here, preventDefault swallows the link's activation, and the row
+      // toggles unexpectedly.
+      if (event.target !== event.currentTarget) return;
       if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault();
         toggleBlock(blockId);

--- a/src/components/RecentBlocksPanel.tsx
+++ b/src/components/RecentBlocksPanel.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import React from 'react';
+import Link from 'next/link';
+import { useApiData } from '../hooks/useApiData';
+import { api } from '../lib/api';
+import { useNetwork } from '../hooks/useNetwork';
+import { useBlobWebSocket } from '../contexts/LiveDataContext';
+import { transformNewBlockData } from '../lib/api/blocks';
+import DataStateWrapper from './DataStateWrapper';
+import { BlobDetailsContent } from './BlobDetailsContent';
+import { Block, LatestBlocksResponse } from '../types';
+import { formatBlobFee, formatPercent } from '../utils';
+import { HOMEPAGE_BLOCK_ROWS } from '../constants';
+
+function FullnessBar({ percent, isAboveTarget }: { percent: number; isAboveTarget: boolean }) {
+  const boundedPercent = Math.min(100, Math.max(0, percent));
+  const fillClass = isAboveTarget ? 'bg-amber-300' : 'bg-green-400';
+
+  return (
+    <div className="h-2 overflow-hidden rounded-full bg-[#202538]">
+      <div
+        className={`h-full rounded-full ${fillClass}`}
+        style={{ width: `${boundedPercent}%` }}
+      />
+    </div>
+  );
+}
+
+function formatBaseFee(block: Block): string {
+  if (!block.baseFeeGwei || block.baseFeeGwei === '0') return '-';
+  return formatBlobFee(block.baseFeeGwei);
+}
+
+function getBlockState(block: Block): string {
+  if (block.isFull) return 'Full';
+  if (block.isAboveTarget) return 'Above target';
+  return 'Under target';
+}
+
+function BlockRow({
+  block,
+  isExpanded,
+  onToggle,
+  onKeyDown,
+}: {
+  block: Block;
+  isExpanded: boolean;
+  onToggle: () => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
+}) {
+  const detailsId = `recent-block-${block.id}-details`;
+  const fillLabel = block.maxBlobs > 0 ? `${block.blobCount}/${block.maxBlobs}` : `${block.blobCount}`;
+  const utilization = block.maxBlobs > 0 ? formatPercent(block.utilizationPercent, 0) : '-';
+
+  return (
+    <div
+      className={`rounded-md border transition-colors ${
+        isExpanded
+          ? 'border-blue/40 bg-[#181d2e]/80'
+          : 'border-divider/70 bg-[#111522]/70 hover:border-blue/30 hover:bg-[#181d2e]/60'
+      }`}
+    >
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={isExpanded}
+        aria-controls={detailsId}
+        aria-label={`View blob details for block ${block.number}`}
+        onClick={onToggle}
+        onKeyDown={onKeyDown}
+        className="grid grid-cols-2 sm:grid-cols-[1.25rem_minmax(5.5rem,0.8fr)_minmax(8rem,1.2fr)_minmax(7rem,1fr)_minmax(5.5rem,0.8fr)] items-center gap-3 px-3 py-2 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-blue focus-visible:ring-inset rounded-md"
+      >
+        <i
+          className={`hidden sm:inline fa-regular fa-chevron-right text-[10px] text-[#6e7787] transition-transform ${
+            isExpanded ? 'rotate-90' : ''
+          }`}
+          aria-hidden="true"
+        />
+        <div className="min-w-0">
+          <div className="text-[11px] text-[#8f9aad]">Block</div>
+          <div className="truncate text-sm font-medium text-white">
+            {block.blockUrl ? (
+              <a
+                href={block.blockUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue hover:underline"
+                onClick={(event) => event.stopPropagation()}
+              >
+                {Number(block.number).toLocaleString()}
+              </a>
+            ) : (
+              Number(block.number).toLocaleString()
+            )}
+          </div>
+        </div>
+        <div className="min-w-0">
+          <div className="mb-1 flex items-center justify-between gap-2 text-[11px] text-[#8f9aad]">
+            <span>{fillLabel} blobs</span>
+            <span>{utilization}</span>
+          </div>
+          <FullnessBar percent={block.utilizationPercent} isAboveTarget={block.isAboveTarget} />
+        </div>
+        <div className="min-w-0">
+          <div className="text-[11px] text-[#8f9aad]">Base fee</div>
+          <div className="truncate text-sm font-medium text-white">{formatBaseFee(block)}</div>
+        </div>
+        <div className="min-w-0">
+          <div className="text-[11px] text-[#8f9aad]">State</div>
+          <div className="truncate text-sm font-medium text-white">{getBlockState(block)}</div>
+        </div>
+      </div>
+      {isExpanded && (
+        <div id={detailsId} className="bg-[#0f1322] rounded-b-md">
+          <BlobDetailsContent block={block} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+type SelectionState = { kind: 'default' } | { kind: 'explicit'; blockId: number | null };
+
+export default function RecentBlocksPanel() {
+  const { selectedNetwork } = useNetwork();
+  const { latestEvents } = useBlobWebSocket();
+  const [selection, setSelection] = React.useState<SelectionState>({ kind: 'default' });
+  const [networkKey, setNetworkKey] = React.useState(selectedNetwork.apiParam);
+
+  if (networkKey !== selectedNetwork.apiParam) {
+    setNetworkKey(selectedNetwork.apiParam);
+    setSelection({ kind: 'default' });
+  }
+
+  const { data, isLoading, error } = useApiData<LatestBlocksResponse>(
+    () => api.getLatestBlocks(HOMEPAGE_BLOCK_ROWS, selectedNetwork.apiParam),
+    undefined,
+    selectedNetwork.apiParam
+  );
+
+  const displayBlocks = React.useMemo<Block[]>(() => {
+    const baseBlocks = data?.data ?? [];
+    if (!latestEvents.new_block) return baseBlocks.slice(0, HOMEPAGE_BLOCK_ROWS);
+
+    const liveBlock = transformNewBlockData(latestEvents.new_block.data);
+    return [
+      liveBlock,
+      ...baseBlocks.filter((block) => block.number !== liveBlock.number),
+    ].slice(0, HOMEPAGE_BLOCK_ROWS);
+  }, [data, latestEvents.new_block]);
+
+  const defaultExpandedId =
+    displayBlocks.find((block) => block.blobs.length > 0)?.id ?? displayBlocks[0]?.id ?? null;
+  const expandedBlockId =
+    selection.kind === 'explicit' && displayBlocks.some((block) => block.id === selection.blockId)
+      ? selection.blockId
+      : defaultExpandedId;
+
+  const toggleBlock = React.useCallback((blockId: number) => {
+    setSelection((current) => {
+      if (current.kind === 'explicit' && current.blockId === blockId) {
+        return { kind: 'explicit', blockId: null };
+      }
+      return { kind: 'explicit', blockId };
+    });
+  }, []);
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>, blockId: number) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        toggleBlock(blockId);
+      }
+    },
+    [toggleBlock]
+  );
+
+  const loadingComponent = (
+    <article className="rounded-lg border border-divider bg-[#161a29]/80 p-5">
+      <div className="space-y-3">
+        {[...Array(HOMEPAGE_BLOCK_ROWS)].map((_, index) => (
+          <div
+            key={index}
+            className="grid grid-cols-2 sm:grid-cols-[minmax(5.5rem,0.8fr)_minmax(8rem,1.2fr)_minmax(7rem,1fr)_minmax(5.5rem,0.8fr)] items-center gap-3 rounded-md border border-divider/70 bg-[#111522]/70 px-3 py-3 animate-pulse"
+          >
+            <div className="h-5 bg-[#202538] rounded w-20" />
+            <div className="h-5 bg-[#202538] rounded" />
+            <div className="h-5 bg-[#202538] rounded w-24" />
+            <div className="h-5 bg-[#202538] rounded w-20" />
+          </div>
+        ))}
+      </div>
+    </article>
+  );
+
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-4 gap-3">
+        <h2 className="text-2xl font-windsor-bold text-white">Recent Block Fees</h2>
+        <Link
+          href="/blocks"
+          className="text-sm text-blue hover:underline whitespace-nowrap"
+        >
+          View all blocks <i className="fa-regular fa-arrow-right text-xs ml-1" aria-hidden="true" />
+        </Link>
+      </div>
+
+      <DataStateWrapper
+        isLoading={isLoading && displayBlocks.length === 0}
+        error={displayBlocks.length === 0 ? error : null}
+        loadingComponent={loadingComponent}
+      >
+        <article className="rounded-lg border border-divider bg-[#161a29]/80 p-5">
+          <div className="space-y-3">
+            {displayBlocks.map((block) => (
+              <BlockRow
+                key={block.id}
+                block={block}
+                isExpanded={expandedBlockId === block.id}
+                onToggle={() => toggleBlock(block.id)}
+                onKeyDown={(event) => handleKeyDown(event, block.id)}
+              />
+            ))}
+          </div>
+        </article>
+      </DataStateWrapper>
+    </section>
+  );
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,8 +4,9 @@
 
 export const APP_NAME = 'Blob Flow';
 export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://blob-indexer.ahkc.win/api/v1';
-export const DASHBOARD_LATEST_BLOB_LIMIT = 200;
-export const LATEST_BLOCK_ROWS = 20;
+export const HOMEPAGE_BLOCK_ROWS = 5;
+export const BLOCKS_PAGE_LIMIT = 100;
+export const BLOCKS_PAGE_SIZE = 20;
 
 /**
  * Network configuration


### PR DESCRIPTION
## Summary

The homepage "Latest Blocks & Blob Fees" section took up the whole top of the page. This swaps it for a compact **Recent Block Fees** panel beside **Data Trends**, and moves the full detailed table to a new **/blocks** page with client-side pagination.

- **Homepage top row** is now a 2-col grid (`lg:grid-cols-2`, `items-start`):
  - **Left:** new `RecentBlocksPanel` — 5 latest blocks in the existing fee-card row style, click any row to drill into per-blob details inline, "View all blocks →" link in the header.
  - **Right:** existing `MetricsCharts` (Data Trends) — unchanged, just relocated from the bottom-right column.
- **`BlobMarketPanels` trimmed** to just the `CurrentMarketPanel` (the old `RecentFeeBlocksPanel` half is now replaced by `RecentBlocksPanel` up top). Sits full-width below the top row.
- **New `/blocks` route** mounts `LatestBlocksTable` with built-in pagination: fetches 100 latest blocks, paginates 20 per page, with prev/next buttons and a "Showing X–Y of N" range counter. Live websocket new-block updates still prepend to page 1.
- **`LatestBlocksTable` refactor:** page state + memoized slice, removed inline blob-detail JSX (now in shared `BlobDetailsContent`), dropped the embedded section wrapper so the `/blocks` page supplies its own header.
- **New shared `BlobDetailsContent` component** extracted from `LatestBlocksTable` so both the homepage panel and the detailed table render blob breakdowns from the same source.

## Why

The original table dominated the homepage at 20 rows × 6 columns and pushed everything else below the fold. The new layout puts a compact 5-row glance + market trends side-by-side at the top, with the deep view a click away.

## Notes

- Backend has no offset/cursor on `/blob/pricing` or `/blob/latest`, so pagination is intentionally client-side over the latest 100 blocks. Easy to swap to true pagination later if the API gets it.
- Top row uses `items-start` so the 5-row panel doesn't stretch to match Data Trends — there's some empty space below it on wide viewports. Happy to rebalance (shorten Data Trends or stretch the panel) if you'd rather.
- `RecentBlocksPanel` deliberately uses the React 19 "set-state-during-render" pattern (instead of `useEffect`-and-setState) for the auto-expand/network-reset logic, so it adds zero new `react-hooks/set-state-in-effect` lint violations.

## Test plan

- [ ] Homepage `/`: confirm top row is `[Recent Block Fees | Data Trends]` on `lg+`, stacked on mobile.
- [ ] Recent Block Fees: first block with blobs auto-expands; clicking another row toggles its blob details.
- [ ] "View all blocks →" link navigates to `/blocks`.
- [ ] `/blocks`: 20 rows per page, prev disabled on page 1, next disabled on page 5, "Showing 1–20 of 100" updates correctly.
- [ ] Network switcher (Mainnet ↔ Sepolia) resets pagination to page 1 and clears any expanded block.
- [ ] Live websocket `new_block` events still prepend to the homepage panel and to page 1 of `/blocks`.
- [ ] `BlobMarketPanels` section below shows just the Current Blob Market panel (no longer a 2-col grid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)