### PR TITLE
fix(blocks): start Recent Block Fees with no row expanded

### DIFF
--- a/src/components/RecentBlocksPanel.tsx
+++ b/src/components/RecentBlocksPanel.tsx
@@ -120,17 +120,15 @@ function BlockRow({
   );
 }
 
-type SelectionState = { kind: 'default' } | { kind: 'explicit'; blockId: number | null };
-
 export default function RecentBlocksPanel() {
   const { selectedNetwork } = useNetwork();
   const liveBlockEvent = useLatestBlobEvent('new_block');
-  const [selection, setSelection] = React.useState<SelectionState>({ kind: 'default' });
+  const [expandedBlockId, setExpandedBlockId] = React.useState<number | null>(null);
   const [networkKey, setNetworkKey] = React.useState(selectedNetwork.apiParam);
 
   if (networkKey !== selectedNetwork.apiParam) {
     setNetworkKey(selectedNetwork.apiParam);
-    setSelection({ kind: 'default' });
+    setExpandedBlockId(null);
   }
 
   const { data, isLoading, error } = useApiData<LatestBlocksResponse>(
@@ -150,30 +148,8 @@ export default function RecentBlocksPanel() {
     ].slice(0, HOMEPAGE_BLOCK_ROWS);
   }, [data, liveBlockEvent]);
 
-  const defaultExpandedId =
-    displayBlocks.find((block) => block.blobs.length > 0)?.id ?? displayBlocks[0]?.id ?? null;
-
-  let expandedBlockId: number | null;
-  if (selection.kind === 'default') {
-    expandedBlockId = defaultExpandedId;
-  } else if (selection.blockId === null) {
-    // user explicitly collapsed the row — keep it closed
-    expandedBlockId = null;
-  } else if (displayBlocks.some((block) => block.id === selection.blockId)) {
-    expandedBlockId = selection.blockId;
-  } else {
-    // explicit selection points at a block that's no longer visible (e.g. after
-    // a network switch or paged-out block) — fall back to the default
-    expandedBlockId = defaultExpandedId;
-  }
-
   const toggleBlock = React.useCallback((blockId: number) => {
-    setSelection((current) => {
-      if (current.kind === 'explicit' && current.blockId === blockId) {
-        return { kind: 'explicit', blockId: null };
-      }
-      return { kind: 'explicit', blockId };
-    });
+    setExpandedBlockId((current) => (current === blockId ? null : blockId));
   }, []);
 
   const handleKeyDown = React.useCallback(


### PR DESCRIPTION
## Summary
- The Recent Block Fees panel auto-expanded the first block (or first with blobs) on load and after network switches.
- Replaced the default/explicit selection state machine with a single `expandedBlockId: number | null` that starts as `null` and is only set by user clicks.
- Network switches reset to closed, and toggling the same row collapses it.

## Test plan
- [ ] Load homepage — no block row in Recent Block Fees is expanded.
- [ ] Click a row — it expands; click it again — it collapses.
- [ ] Expand a row, switch networks — panel reloads with everything collapsed.
- [ ] Click the block-number link inside a row — link opens, row state doesn't toggle (existing behavior preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)