### PR TITLE
style(layout): make Blob Market section half width on large screens

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,7 +25,7 @@ export default function Home() {
           <MetricsCharts />
         </div>
 
-        <div className="mb-12">
+        <div className="mb-12 lg:w-1/2 lg:pr-6">
           <BlobMarketPanels />
         </div>
 


### PR DESCRIPTION
## Summary
- Constrain the Blob Market section to half the container width on `lg` and up via `lg:w-1/2 lg:pr-6`, matching the column gap of the grid row above it.
- Mobile and tablet layouts remain full-width.

## Test plan
- [ ] Verify `npm run dev` renders Blob Market at half width at `lg` (≥1024px).
- [ ] Verify Blob Market remains full-width below the `lg` breakpoint.
- [ ] Confirm no regressions in surrounding sections (LiveMetrics, RecentBlocksPanel, MetricsCharts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)