### PR TITLE
style(layout): stack Blob Market under MetricsCharts to fill dead space

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,11 +22,10 @@ export default function Home() {
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-start mb-12">
           <RecentBlocksPanel />
-          <MetricsCharts />
-        </div>
-
-        <div className="mb-12 lg:w-1/2 lg:pr-6">
-          <BlobMarketPanels />
+          <div className="space-y-12">
+            <MetricsCharts />
+            <BlobMarketPanels />
+          </div>
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-5 gap-12">


### PR DESCRIPTION
## Summary
- Moves `BlobMarketPanels` into the right column of the existing two-column grid alongside `MetricsCharts` in [src/app/page.tsx](src/app/page.tsx).
- With `items-start` already on the grid, the right column now stacks both panels and rises to fill the space next to the taller `RecentBlocksPanel`, eliminating the half-empty row Blob Market previously sat on.

## Test plan
- [ ] Load the dashboard at `lg` width and confirm Blob Market sits directly under MetricsCharts in the right column with no dead space.
- [ ] At narrow widths, confirm the panels stack vertically in the expected order (RecentBlocks → MetricsCharts → BlobMarket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)