### PR TITLE
style(layout): place Blob Market under Recent Block Fees

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,11 +21,11 @@ export default function Home() {
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-start mb-12">
-          <RecentBlocksPanel />
           <div className="space-y-12">
-            <MetricsCharts />
+            <RecentBlocksPanel />
             <BlobMarketPanels />
           </div>
+          <MetricsCharts />
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-5 gap-12">


### PR DESCRIPTION
## Summary
- Moves `BlobMarketPanels` into the left column beneath `RecentBlocksPanel` in [src/app/page.tsx](src/app/page.tsx) so it sits immediately under **Recent Block Fees**.
- `MetricsCharts` now stands alone in the right column; with `items-start` the right column stays top-aligned and the left column flows Recent Block Fees → Blob Market vertically.

## Test plan
- [ ] At `lg` width, confirm Blob Market appears directly under Recent Block Fees on the left, with MetricsCharts on the right.
- [ ] At narrow widths, confirm the panels stack in order: Recent Block Fees → Blob Market → MetricsCharts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)