### PR TITLE
feat(blocks): add block detail page with Etherscan link

### DIFF
--- a/src/app/block/[number]/page.tsx
+++ b/src/app/block/[number]/page.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+import DataStateWrapper from '@/components/DataStateWrapper';
+import { BlobDetailsContent } from '@/components/BlobDetailsContent';
+import { useApiData } from '@/hooks/useApiData';
+import { api } from '@/lib/api';
+import { useNetwork } from '@/hooks/useNetwork';
+import { Block } from '@/types';
+import { formatBlobFee, formatUtilizationPercent } from '@/utils';
+
+function formatBaseFee(block: Block): string {
+  if (!block.baseFeeGwei || block.baseFeeGwei === '0') return '-';
+  return formatBlobFee(block.baseFeeGwei);
+}
+
+function formatOpenCapacity(block: Block): string {
+  if (block.maxBlobs <= 0) return '-';
+  return `${block.availableBlobs}/${block.maxBlobs} open`;
+}
+
+function formatUtilization(block: Block): string {
+  if (block.maxBlobs <= 0) return '-';
+  return formatUtilizationPercent(block.utilizationPercent);
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-gradient-to-b from-[#22252c] to-[#16171b] border border-divider rounded-lg p-4">
+      <div className="text-xs text-[#6e7787] uppercase tracking-wider mb-1">{label}</div>
+      <div className="text-xl text-white font-medium">{value}</div>
+    </div>
+  );
+}
+
+export default function BlockDetailPage() {
+  const params = useParams();
+  const rawNumber = params.number as string;
+  const blockNumber = Number(rawNumber);
+  const isValidNumber = Number.isFinite(blockNumber) && blockNumber > 0;
+  const { selectedNetwork } = useNetwork();
+  const refetchKey = `${selectedNetwork.apiParam}:${rawNumber}`;
+
+  const { data: block, isLoading, error } = useApiData<Block | null>(
+    () =>
+      isValidNumber
+        ? api.getBlockByNumber(blockNumber, selectedNetwork.apiParam)
+        : Promise.resolve(null),
+    undefined,
+    refetchKey
+  );
+
+  const loadingComponent = (
+    <div className="space-y-6">
+      <div className="h-8 bg-[#202538] rounded w-64 animate-pulse" />
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="bg-gradient-to-b from-[#22252c] to-[#16171b] border border-divider rounded-lg p-4">
+            <div className="h-3 bg-[#202538] rounded w-20 animate-pulse mb-2" />
+            <div className="h-6 bg-[#202538] rounded w-24 animate-pulse" />
+          </div>
+        ))}
+      </div>
+      <div className="border border-divider rounded-lg p-6">
+        <div className="h-5 bg-[#202538] rounded w-40 animate-pulse mb-4" />
+        <div className="space-y-3">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="h-12 bg-[#202538] rounded animate-pulse" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <main className="min-h-screen bg-background bg-grid-pattern bg-grid-size">
+      <Header />
+      <div className="container mx-auto px-4 py-8 max-w-7xl">
+        <Link
+          href="/blocks"
+          className="text-blue hover:underline text-sm mb-6 inline-flex items-center gap-2"
+        >
+          <i className="fa-regular fa-arrow-left" aria-hidden="true" />
+          Back to Blocks
+        </Link>
+
+        {!isValidNumber ? (
+          <div className="rounded-lg border border-divider bg-[#161a29]/80 p-6">
+            <h1 className="text-2xl font-windsor-bold text-white mb-2">Invalid block</h1>
+            <p className="text-bodyText text-sm">
+              &ldquo;{rawNumber}&rdquo; is not a valid block number.
+            </p>
+          </div>
+        ) : (
+          <DataStateWrapper isLoading={isLoading} error={error} loadingComponent={loadingComponent}>
+            {block === null ? (
+              <div className="rounded-lg border border-divider bg-[#161a29]/80 p-6">
+                <h1 className="text-2xl font-windsor-bold text-white mb-2">
+                  Block {blockNumber.toLocaleString()}
+                </h1>
+                <p className="text-bodyText text-sm mb-4">
+                  This block isn&rsquo;t available in the latest indexed window for{' '}
+                  {selectedNetwork.name}. It may be older than the indexer&rsquo;s retention.
+                </p>
+                <a
+                  href={`https://etherscan.io/block/${blockNumber}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue hover:underline text-sm inline-flex items-center gap-2"
+                >
+                  View on Etherscan
+                  <i className="fa-regular fa-arrow-up-right-from-square text-xs" aria-hidden="true" />
+                </a>
+              </div>
+            ) : block ? (
+              <>
+                <div className="mb-8">
+                  <div className="flex flex-wrap items-baseline justify-between gap-3 mb-2">
+                    <h1 className="text-3xl font-windsor-bold text-white">
+                      Block {Number(block.number).toLocaleString()}
+                    </h1>
+                    {block.blockUrl && (
+                      <a
+                        href={block.blockUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue hover:underline text-sm inline-flex items-center gap-2"
+                      >
+                        View on Etherscan
+                        <i
+                          className="fa-regular fa-arrow-up-right-from-square text-xs"
+                          aria-hidden="true"
+                        />
+                      </a>
+                    )}
+                  </div>
+                  <p className="text-bodyText text-sm mb-6">
+                    {block.timestamp}
+                    {block.isFull && (
+                      <span className="ml-3 text-[10px] uppercase tracking-wider text-[#ff8f8f]">
+                        Full
+                      </span>
+                    )}
+                    {!block.isFull && block.isAboveTarget && (
+                      <span className="ml-3 text-[10px] uppercase tracking-wider text-[#ffb86b]">
+                        Above target
+                      </span>
+                    )}
+                  </p>
+
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                    <StatCard label="Blobs" value={block.blobCount.toLocaleString()} />
+                    <StatCard label="Utilization" value={formatUtilization(block)} />
+                    <StatCard label="Base Fee" value={formatBaseFee(block)} />
+                    <StatCard label="Open Capacity" value={formatOpenCapacity(block)} />
+                  </div>
+                </div>
+
+                <section>
+                  <h2 className="text-2xl font-windsor-bold text-white mb-4">Blobs</h2>
+                  <div className="border border-divider rounded-lg bg-[#0f1322]">
+                    <BlobDetailsContent block={block} />
+                  </div>
+                </section>
+              </>
+            ) : null}
+          </DataStateWrapper>
+        )}
+      </div>
+      <Footer />
+    </main>
+  );
+}

--- a/src/app/user/[address]/page.tsx
+++ b/src/app/user/[address]/page.tsx
@@ -90,25 +90,25 @@ function BlobTable({ blobs, showBlock }: { blobs: BlobResponse[]; showBlock: boo
                   <div className="text-xs text-[#8a93a5] mt-1 font-sans whitespace-nowrap">blob #{blob.blob_index}</div>
                   {showBlock && (
                     <div className="text-xs text-[#8a93a5] mt-1 font-sans sm:hidden">
-                      block {blob.block_number}
+                      block{' '}
+                      <Link
+                        href={`/block/${blob.block_number}`}
+                        className="text-blue hover:underline"
+                      >
+                        {blob.block_number}
+                      </Link>
                     </div>
                   )}
                   <div className="text-xs text-[#8a93a5] mt-1 font-sans whitespace-nowrap lg:hidden">{formatRelativeTime(blob.timestamp)}</div>
                 </td>
                 {showBlock && (
                   <td className={`hidden sm:table-cell py-3 px-3 sm:px-4 text-sm text-white ${blockWidth}`}>
-                    {blob.block_url ? (
-                      <a
-                        href={blob.block_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-blue hover:underline"
-                      >
-                        {blob.block_number}
-                      </a>
-                    ) : (
-                      <span>{blob.block_number}</span>
-                    )}
+                    <Link
+                      href={`/block/${blob.block_number}`}
+                      className="text-blue hover:underline"
+                    >
+                      {blob.block_number}
+                    </Link>
                   </td>
                 )}
                 <td className="py-3 px-3 sm:px-4 text-sm text-white whitespace-nowrap">

--- a/src/components/BlobMarketPanels.tsx
+++ b/src/components/BlobMarketPanels.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
 import { useLiveBlobEvent } from '@/contexts/LiveDataContext';
 import { useNetwork } from '@/hooks/useNetwork';
 import { api } from '@/lib/api';
@@ -147,7 +148,12 @@ function CurrentMarketPanel({ pricing }: { pricing: BlobPricing }) {
       {latestBlock && (
         <div className="mt-5 border-t border-divider pt-5">
           <div className="mb-2 flex items-center justify-between gap-3 text-sm">
-            <span className="text-white">Block {latestBlock.blockNumber.toLocaleString()}</span>
+            <Link
+              href={`/block/${latestBlock.blockNumber}`}
+              className="text-blue hover:underline"
+            >
+              Block {latestBlock.blockNumber.toLocaleString()}
+            </Link>
             <span className="text-[#8f9aad]">{utilizationPercent} full</span>
           </div>
           <FullnessBar percent={latestBlock.utilizationPercent} isAboveTarget={latestBlock.isAboveTarget} />

--- a/src/components/LatestBlocksTable.tsx
+++ b/src/components/LatestBlocksTable.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useApiData } from '../hooks/useApiData';
 import { api } from '../lib/api';
 import { Block, BlobResponse, LatestBlocksResponse } from '../types';
@@ -328,19 +329,13 @@ export default function LatestBlocksTable() {
                               }`}
                               aria-hidden="true"
                             />
-                            {block.blockUrl ? (
-                              <a
-                                href={block.blockUrl}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-blue hover:underline"
-                                onClick={(event) => event.stopPropagation()}
-                              >
-                                {Number(block.number).toLocaleString()}
-                              </a>
-                            ) : (
-                              <span>{Number(block.number).toLocaleString()}</span>
-                            )}
+                            <Link
+                              href={`/block/${block.number}`}
+                              className="text-blue hover:underline"
+                              onClick={(event) => event.stopPropagation()}
+                            >
+                              {Number(block.number).toLocaleString()}
+                            </Link>
                           </div>
                           <div className="text-xs text-[#8a93a5] mt-1 font-normal whitespace-nowrap">{block.timestamp}</div>
                           <div className="text-xs text-[#8a93a5] mt-1 font-normal sm:hidden">{baseFee}</div>

--- a/src/components/RecentBlocksPanel.tsx
+++ b/src/components/RecentBlocksPanel.tsx
@@ -80,19 +80,13 @@ function BlockRow({
         <div className="min-w-0">
           <div className="text-[11px] text-[#8f9aad]">Block</div>
           <div className="truncate text-sm font-medium text-white">
-            {block.blockUrl ? (
-              <a
-                href={block.blockUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue hover:underline"
-                onClick={(event) => event.stopPropagation()}
-              >
-                {Number(block.number).toLocaleString()}
-              </a>
-            ) : (
-              Number(block.number).toLocaleString()
-            )}
+            <Link
+              href={`/block/${block.number}`}
+              className="text-blue hover:underline"
+              onClick={(event) => event.stopPropagation()}
+            >
+              {Number(block.number).toLocaleString()}
+            </Link>
           </div>
         </div>
         <div className="min-w-0">

--- a/src/lib/api/blocks.ts
+++ b/src/lib/api/blocks.ts
@@ -132,3 +132,20 @@ export async function getLatestBlocks(limit = 20, network?: string): Promise<Lat
 export async function getBlobByTxHash(txHash: string, network?: string): Promise<ApiResponse<BlobResponse>> {
     return fetchApi<ApiResponse<BlobResponse>>(`/blob/${txHash}`, network);
 }
+
+/**
+ * Get a single block by number. The backend has no per-block endpoint, so this
+ * walks the latest pricing window and returns the matching block (with blob
+ * details) if it falls within the most recent {@link limit} blocks.
+ * @param blockNumber - Block number to retrieve
+ * @param network - Optional network parameter
+ * @param limit - How many recent blocks to scan
+ */
+export async function getBlockByNumber(
+    blockNumber: number,
+    network?: string,
+    limit = 100,
+): Promise<Block | null> {
+    const { data } = await getLatestBlocks(limit, network);
+    return data.find((block) => block.number === blockNumber.toString()) ?? null;
+}

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,4 +1,4 @@
-import { getLatestBlocks, getBlobByTxHash } from './blocks';
+import { getBlockByNumber, getLatestBlocks, getBlobByTxHash } from './blocks';
 import { getRawBlobs } from './blobs';
 import { getMempool, getMempoolPressure } from './mempool';
 import { getBlobPricing } from './pricing';
@@ -8,6 +8,7 @@ import { getTopUsers, getUserByAddress, getUserBlobs } from './users';
 
 export const api = {
     getLatestBlocks,
+    getBlockByNumber,
     getBlobByTxHash,
     getRawBlobs,
     getBlobPricing,


### PR DESCRIPTION
## Summary
- New `/block/[number]` page renders a block summary (blobs, utilization, base fee, open capacity) plus the existing per-blob breakdown, with a "View on Etherscan" link sourced from `block.blockUrl`.
- Block-number links across the app (`LatestBlocksTable`, `RecentBlocksPanel`, `BlobMarketPanels`, user detail page) now route to the new page instead of jumping straight to Etherscan.
- Adds `api.getBlockByNumber`, which reuses `getLatestBlocks` and filters by number — the backend has no per-block endpoint, so the detail page only resolves blocks inside the latest pricing window; older blocks land on a fallback view with a constructed Etherscan link.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test -- --run src/lib/api/blocks.test.ts`
- [ ] Click a block on `/` (Recent Block Fees) and `/blocks` — verify it navigates to `/block/[number]` and the Etherscan link works.
- [ ] Visit `/block/<very-old-number>` — verify the fallback view with the Etherscan link renders.
- [ ] Switch networks on the detail page — verify the block reloads against the new network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)