### PR TITLE
feat(ui): tick relative timestamps every second

### DIFF
--- a/src/app/user/[address]/page.tsx
+++ b/src/app/user/[address]/page.tsx
@@ -23,7 +23,7 @@ import {
   getBlobCount,
   truncateAddress,
 } from '@/utils';
-import { formatRelativeTime } from '@/lib/api/core';
+import { RelativeTime } from '@/components/RelativeTime';
 
 function truncateTxHash(hash: string): string {
   if (hash.length <= 14) return hash;
@@ -93,7 +93,7 @@ function BlobTable({ blobs, showBlock }: { blobs: BlobResponse[]; showBlock: boo
                       block {blob.block_number}
                     </div>
                   )}
-                  <div className="text-xs text-[#8a93a5] mt-1 font-sans whitespace-nowrap lg:hidden">{formatRelativeTime(blob.timestamp)}</div>
+                  <div className="text-xs text-[#8a93a5] mt-1 font-sans whitespace-nowrap lg:hidden"><RelativeTime timestamp={blob.timestamp} /></div>
                 </td>
                 {showBlock && (
                   <td className={`hidden sm:table-cell py-3 px-3 sm:px-4 text-sm text-white ${blockWidth}`}>
@@ -126,7 +126,7 @@ function BlobTable({ blobs, showBlock }: { blobs: BlobResponse[]; showBlock: boo
                   <div className="text-xs text-[#8a93a5] mt-1 whitespace-nowrap">{headroom} room</div>
                   <div className="text-xs text-[#8a93a5] mt-1 whitespace-nowrap md:hidden">{baseFee}</div>
                 </td>
-                <td className="hidden lg:table-cell py-3 px-3 sm:px-4 text-sm text-white whitespace-nowrap">{formatRelativeTime(blob.timestamp)}</td>
+                <td className="hidden lg:table-cell py-3 px-3 sm:px-4 text-sm text-white whitespace-nowrap"><RelativeTime timestamp={blob.timestamp} /></td>
               </tr>
             );
           })}
@@ -251,7 +251,7 @@ export default function UserDetailPage() {
                 </div>
                 <div className="bg-gradient-to-b from-[#22252c] to-[#16171b] border border-divider rounded-lg p-4">
                   <div className="text-xs text-[#6e7787] uppercase tracking-wider mb-1">Last Active</div>
-                  <div className="text-xl text-white font-medium">{formatRelativeTime(user.last_timestamp)}</div>
+                  <div className="text-xl text-white font-medium"><RelativeTime timestamp={user.last_timestamp} /></div>
                 </div>
               </div>
             </div>

--- a/src/components/BlobDetailsContent.tsx
+++ b/src/components/BlobDetailsContent.tsx
@@ -13,7 +13,7 @@ import {
   getAttributionInitial,
   truncateAddress,
 } from '../utils';
-import { formatRelativeTime } from '../lib/api/core';
+import { RelativeTime } from './RelativeTime';
 
 function truncateTxHash(hash: string): string {
   if (hash.length <= 14) return hash;
@@ -144,7 +144,7 @@ export function BlobDetailsContent({ block }: { block: Block }) {
                     {maxFee}
                   </BlobDetailField>
                   <BlobDetailField label="Headroom">{headroom}</BlobDetailField>
-                  <BlobDetailField label="Time">{formatRelativeTime(blob.timestamp)}</BlobDetailField>
+                  <BlobDetailField label="Time"><RelativeTime timestamp={blob.timestamp} /></BlobDetailField>
                   <BlobDetailField label="Status">
                     {blob.confirmed ? 'Confirmed' : 'Pending'}
                   </BlobDetailField>

--- a/src/components/LatestBlocksTable.tsx
+++ b/src/components/LatestBlocksTable.tsx
@@ -20,6 +20,7 @@ import { transformNewBlockData } from '../lib/api/blocks';
 import { BlobDetailsContent } from './BlobDetailsContent';
 import { BLOCKS_PAGE_LIMIT, BLOCKS_PAGE_SIZE } from '../constants';
 import { useFlipRows } from '../hooks/useFlipRows';
+import { RelativeTime } from './RelativeTime';
 
 function getBlockDetailsId(blockId: number): string {
   return `block-${blockId}-blob-details`;
@@ -342,7 +343,7 @@ export default function LatestBlocksTable() {
                               <span>{Number(block.number).toLocaleString()}</span>
                             )}
                           </div>
-                          <div className="text-xs text-[#8a93a5] mt-1 font-normal whitespace-nowrap">{block.timestamp}</div>
+                          <div className="text-xs text-[#8a93a5] mt-1 font-normal whitespace-nowrap"><RelativeTime timestamp={block.timestamp} /></div>
                           <div className="text-xs text-[#8a93a5] mt-1 font-normal sm:hidden">{baseFee}</div>
                         </td>
                         <td className="py-3 px-3 sm:px-4 text-sm text-white">

--- a/src/components/LiveMetrics.tsx
+++ b/src/components/LiveMetrics.tsx
@@ -18,6 +18,8 @@ import DataStateWrapper from './DataStateWrapper';
 import { useNetwork } from '../hooks/useNetwork';
 import { useTimeRange } from '../contexts/TimeRangeContext';
 import { useLatestBlobEvent, useLiveBlobEvent } from '../contexts/LiveDataContext';
+import { useNow } from '../hooks/useNow';
+import { formatRelativeTime } from '../lib/api/core';
 
 const LATEST_BLOCKS_SAMPLE = 30;
 
@@ -165,6 +167,8 @@ export default function LiveMetrics() {
     [latestBlocks]
   );
 
+  const now = useNow();
+
   const getMetrics = (
     stats: StatsResponse,
     window: RollingWindowDataPoint,
@@ -183,7 +187,7 @@ export default function LiveMetrics() {
       value: block ? `#${block.id.toLocaleString()}` : '—',
       trend: 'neutral' as const,
       description: block
-        ? `${block.blobCount}${block.maxBlobs ? `/${block.maxBlobs}` : ''} blobs · ${block.timestamp}`
+        ? `${block.blobCount}${block.maxBlobs ? `/${block.maxBlobs}` : ''} blobs · ${formatRelativeTime(block.timestamp, new Date(now))}`
         : 'Waiting for next block',
       icon: 'fa-regular fa-cube',
     },

--- a/src/components/MempoolBlobDetailsModal.tsx
+++ b/src/components/MempoolBlobDetailsModal.tsx
@@ -10,6 +10,7 @@ import {
   getAttributionImageSrc,
   getAttributionInitial,
 } from '../utils';
+import { RelativeTime } from './RelativeTime';
 
 interface MempoolBlobDetailsModalProps {
   transaction: MempoolTransaction | null;
@@ -90,7 +91,7 @@ export default function MempoolBlobDetailsModal({
             <span className="text-sm text-[#b8bdc7]">
               {blob.network_name || `Network ${blob.network_id}`}
             </span>
-            <span className="text-sm text-[#6e7687]">{transaction.timeInMempool}</span>
+            <span className="text-sm text-[#6e7687]"><RelativeTime timestamp={transaction.timeInMempool} /></span>
           </div>
 
           <div className="mb-6 flex items-center gap-3 border-b border-divider pb-5">

--- a/src/components/MempoolTable.tsx
+++ b/src/components/MempoolTable.tsx
@@ -17,6 +17,7 @@ import { useLatestBlobEvent } from '../contexts/LiveDataContext';
 import { transformBlobToMempoolTransaction } from '../lib/api/mempool';
 import { useFlipRows } from '../hooks/useFlipRows';
 import MempoolBlobDetailsModal from './MempoolBlobDetailsModal';
+import { RelativeTime } from './RelativeTime';
 
 export default function MempoolTable() {
   const { selectedNetwork } = useNetwork();
@@ -145,7 +146,7 @@ export default function MempoolTable() {
                         >
                           {truncateTxHash(tx.txHash)}
                         </button>
-                        <div className="text-xs text-[#8a93a5] mt-1 font-sans md:hidden">{tx.timeInMempool}</div>
+                        <div className="text-xs text-[#8a93a5] mt-1 font-sans md:hidden"><RelativeTime timestamp={tx.timeInMempool} /></div>
                       </td>
                       <td className="py-3 px-3 sm:px-4 text-sm text-white min-w-0">
                         <div className="font-mono whitespace-nowrap" title={tx.fromAddressFull}>
@@ -192,7 +193,7 @@ export default function MempoolTable() {
                         <div className="text-xs text-[#8a93a5] mt-1 whitespace-nowrap">max {tx.maxCost}</div>
                         <div className="text-xs text-[#8a93a5] mt-1 whitespace-nowrap sm:hidden">{tx.feeHeadroom} room</div>
                       </td>
-                      <td className="hidden md:table-cell py-3 px-3 sm:px-4 text-sm text-white whitespace-nowrap">{tx.timeInMempool}</td>
+                      <td className="hidden md:table-cell py-3 px-3 sm:px-4 text-sm text-white whitespace-nowrap"><RelativeTime timestamp={tx.timeInMempool} /></td>
                     </tr>
                   );
                 })}

--- a/src/components/RelativeTime.tsx
+++ b/src/components/RelativeTime.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import React from 'react';
+import { useNow } from '../hooks/useNow';
+import { formatRelativeTime } from '../lib/api/core';
+
+export function RelativeTime({ timestamp }: { timestamp: string }) {
+  const now = useNow();
+  return <>{formatRelativeTime(timestamp, new Date(now))}</>;
+}

--- a/src/hooks/useNow.ts
+++ b/src/hooks/useNow.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+
+type Listener = (now: number) => void;
+
+const listeners = new Set<Listener>();
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+function ensureInterval(): void {
+  if (intervalId !== null) return;
+  intervalId = setInterval(() => {
+    const now = Date.now();
+    listeners.forEach((listener) => listener(now));
+  }, 1000);
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  ensureInterval();
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && intervalId !== null) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  };
+}
+
+/**
+ * Returns the current Unix timestamp (ms), ticking once per second.
+ *
+ * All subscribers share a single interval so rendering many relative-time
+ * values stays cheap. The hook starts with the time captured at first render
+ * (after hydration) and updates in place each tick.
+ */
+export function useNow(): number {
+  const [now, setNow] = useState<number>(() => Date.now());
+  useEffect(() => subscribe(setNow), []);
+  return now;
+}

--- a/src/lib/api/blocks.test.ts
+++ b/src/lib/api/blocks.test.ts
@@ -117,7 +117,7 @@ describe('api/blocks', () => {
     expect(result.data[0]).toMatchObject({
       number: '100',
       blobCount: 2,
-      timestamp: '1 min ago',
+      timestamp: '2026-01-01T00:00:00.000Z',
       blockUrl: 'https://etherscan.io/block/100',
       baseFeeGwei: '0.25',
       utilizationPercent: 33.33,

--- a/src/lib/api/blocks.ts
+++ b/src/lib/api/blocks.ts
@@ -7,7 +7,7 @@ import {
     LatestBlocksResponse,
     NewBlockData,
 } from '../../types';
-import { fetchApi, formatRelativeTime } from './core';
+import { fetchApi } from './core';
 
 function getAttributions(blobs: BlobResponse[]): string[] {
     const attributions: string[] = Array.from(new Set(
@@ -55,7 +55,7 @@ export function transformNewBlockData(
         utilizationPercent,
         isFull: pricingBlock?.is_full ?? false,
         isAboveTarget: pricingBlock?.is_above_target ?? false,
-        timestamp: formatRelativeTime(blockData.timestamp),
+        timestamp: blockData.timestamp,
         attribution: getAttributions(blockData.blobs),
         blobs: blockData.blobs
     };

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -11,10 +11,9 @@ const inFlightGetRequests = new Map<string, Promise<unknown>>();
 /**
  * Helper function to format relative time
  */
-export function formatRelativeTime(timestamp: string): string {
+export function formatRelativeTime(timestamp: string, now: Date = new Date()): string {
     const date = new Date(timestamp);
-    const now = new Date();
-    const diffSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+    const diffSeconds = Math.max(0, Math.floor((now.getTime() - date.getTime()) / 1000));
 
     if (diffSeconds < 60) {
         return `${diffSeconds} sec ago`;

--- a/src/lib/api/mempool.test.ts
+++ b/src/lib/api/mempool.test.ts
@@ -62,7 +62,7 @@ describe('api/mempool', () => {
       blobCount: 2,
       maxFeeGwei: '1 Gwei',
       feeHeadroom: '99.6%',
-      timeInMempool: '5 min ago',
+      timeInMempool: '2026-01-01T00:00:00.000Z',
       rawBlob: expect.objectContaining({
         tx_hash: '0xabc',
         from_address: '0x1234567890abcdef',

--- a/src/lib/api/mempool.ts
+++ b/src/lib/api/mempool.ts
@@ -6,7 +6,7 @@ import {
     MempoolResponse,
     MempoolTransaction
 } from '../../types';
-import { fetchApi, formatRelativeTime, truncateAddress } from './core';
+import { fetchApi, truncateAddress } from './core';
 import {
     formatBlobFee,
     formatBlobTotalCost,
@@ -39,7 +39,7 @@ export function transformBlobToMempoolTransaction(blob: BlobResponse, index: num
         realizedCost,
         maxCost: formatBlobWeiCost(blob.max_cost_wei),
         estimatedCost: realizedCost,
-        timeInMempool: formatRelativeTime(blob.timestamp),
+        timeInMempool: blob.timestamp,
         rawBlob: blob,
     };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -150,6 +150,7 @@ export interface Block {
   utilizationPercent: number;
   isFull: boolean;
   isAboveTarget: boolean;
+  /** ISO-8601 timestamp; formatted for display via `<RelativeTime>`. */
   timestamp: string;
   attribution: string[];
   blobs: BlobResponse[];
@@ -178,6 +179,7 @@ export interface MempoolTransaction {
   realizedCost: string;
   maxCost: string;
   estimatedCost: string;
+  /** ISO-8601 timestamp of first-seen; formatted for display via `<RelativeTime>`. */
   timeInMempool: string;
   rawBlob: BlobResponse;
 }


### PR DESCRIPTION
## Summary

- Block ages, mempool wait times, and per-blob timestamps now increment in real time instead of refreshing only when data refetches.
- New `<RelativeTime>` component backed by a shared 1-second `useNow` ticker.
- `Block.timestamp` and `MempoolTransaction.timeInMempool` are now raw ISO strings; formatting happens at render time.

## Why

The display strings (e.g. `"5 sec ago"`) were baked in at API-transform time, so they appeared frozen between refresh cycles. The user-visible behavior reported was that "Block age" sat at the same value for many seconds. Now each subscriber re-renders once per second from a single shared interval, so the seconds counter ticks up live and transitions cleanly into minutes / hours / days.

## Notable details

- A single `setInterval(1000)` is shared across all `useNow` subscribers, started lazily on first subscription and cleared when the last one unmounts — many `<RelativeTime>` cells stay cheap.
- `formatRelativeTime(timestamp, now?)` gained an optional `now` parameter so callers (and tests) can render deterministically. `<RelativeTime>` passes the current tick; `LiveMetrics` does the same inline since its description is interpolated into a string passed to `MetricCard`.
- Test fixtures were updated to expect ISO timestamps on `Block.timestamp` / `MempoolTransaction.timeInMempool`.

## Test plan

- [x] `npm test` — 82 tests pass
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual browser check that the seconds counter visibly ticks on Latest Blocks, Live Metrics, Mempool table, and the user detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)