### PR TITLE
feat(header): add 1h option to time range filter

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -77,7 +77,7 @@ export default function Header() {
   // Lock scrolling when the mobile menu is open
   useScrollLock(isMobileMenuOpen);
 
-  const timeRangeOptions: TimeRange[] = ['24h', '7d', '30d', 'All'];
+  const timeRangeOptions: TimeRange[] = ['1h', '24h', '7d', '30d', 'All'];
 
   const handleNetworkChange = (network: typeof DEFAULT_NETWORK) => {
     setSelectedNetwork(network);

--- a/src/contexts/TimeRangeContext.tsx
+++ b/src/contexts/TimeRangeContext.tsx
@@ -2,7 +2,7 @@
 
 import React, { createContext, useContext, useState, ReactNode } from 'react';
 
-export type TimeRange = '24h' | '7d' | '30d' | 'All';
+export type TimeRange = '1h' | '24h' | '7d' | '30d' | 'All';
 
 interface TimeRangeContextValue {
   timeRange: TimeRange;


### PR DESCRIPTION
## Summary
- Adds `1h` as the first option in the header's time range selector (desktop + mobile menu).
- Extends the `TimeRange` union in `TimeRangeContext` to include `'1h'`.

## Why
The stats backend already returns a `1h` rolling window (it's in `DEFAULT_STATS_WINDOWS`), but the UI had no way to select it. `getRequestedRollingWindow`/`selectRollingWindow` pass the `TimeRange` value straight through to the matching `RollingWindowKey`, so no further wiring is required — picking `1h` will land on the exact rolling-window match.

## Test plan
- [ ] Open dashboard, confirm `1h` button appears as the first time range option in the header
- [ ] Click `1h` and verify the metrics/charts update to use the 1h rolling window
- [ ] On mobile, open the menu tray and verify `1h` shows up in the Time Period selector
- [ ] Confirm the other ranges (`24h`, `7d`, `30d`, `All`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)