### PR TITLE
fix: show top user metric

### DIFF
--- a/src/components/LiveMetrics.tsx
+++ b/src/components/LiveMetrics.tsx
@@ -18,6 +18,7 @@ import DataStateWrapper from './DataStateWrapper';
 import { useNetwork } from '../hooks/useNetwork';
 import { useTimeRange } from '../contexts/TimeRangeContext';
 import { useLatestBlobEvent, useLiveBlobEvent } from '../contexts/LiveDataContext';
+import { truncateAddress } from '../utils';
 
 const LATEST_BLOCKS_SAMPLE = 30;
 
@@ -34,14 +35,21 @@ function formatGwei(value: number): string {
   return `${value.toFixed(2)} Gwei`;
 }
 
-interface TopL2Stat {
+interface TopUserStat {
   name: string;
+  address: string;
   share: number;
   blocksSampled: number;
 }
 
+interface TopUserAggregate {
+  address: string;
+  count: number;
+  attribution?: string;
+}
+
 /**
- * Aggregate `user_attribution` across the supplied blocks to find the dominant L2.
+ * Aggregate blob senders across the supplied blocks to find the dominant user.
  *
  * Only blocks whose joined blob detail covers the entire pricing `blobCount`
  * are included — `/blob/latest` may return fewer records than the pricing
@@ -49,39 +57,59 @@ interface TopL2Stat {
  * share while still claiming to cover the full sample. Partial blocks are
  * dropped from the sample count instead of being misrepresented.
  */
-function computeTopL2(blocks: Block[]): TopL2Stat | null {
+function computeTopUser(blocks: Block[]): TopUserStat | null {
   const completeBlocks = blocks.filter(
     (block) => block.blobs.length >= block.blobCount
   );
   if (completeBlocks.length === 0) return null;
 
-  const counts = new Map<string, number>();
+  const users = new Map<string, TopUserAggregate>();
   let total = 0;
 
   for (const block of completeBlocks) {
     for (const blob of block.blobs) {
-      const name = blob.user_attribution || 'Unknown';
-      counts.set(name, (counts.get(name) || 0) + 1);
+      const address = blob.from_address.trim();
+      if (!address) continue;
+
+      const key = address.toLowerCase();
+      const attribution = getAttributedName(blob.user_attribution);
+      const user = users.get(key);
+      if (user) {
+        user.count += 1;
+        user.attribution ||= attribution;
+      } else {
+        users.set(key, { address, count: 1, attribution });
+      }
       total += 1;
     }
   }
 
   if (total === 0) return null;
 
-  let topName = '';
-  let topCount = 0;
-  counts.forEach((count, name) => {
-    if (count > topCount) {
-      topCount = count;
-      topName = name;
-    }
-  });
+  const topUser = Array.from(users.values()).reduce<TopUserAggregate | null>(
+    (currentTopUser, user) => {
+      if (!currentTopUser || user.count > currentTopUser.count) {
+        return user;
+      }
+      return currentTopUser;
+    },
+    null
+  );
+
+  if (!topUser) return null;
 
   return {
-    name: topName,
-    share: (topCount / total) * 100,
+    name: topUser.attribution || truncateAddress(topUser.address),
+    address: topUser.address,
+    share: (topUser.count / total) * 100,
     blocksSampled: completeBlocks.length,
   };
+}
+
+function getAttributedName(attribution?: string): string | undefined {
+  const name = attribution?.trim();
+  if (!name || name.toLowerCase() === 'unknown') return undefined;
+  return name;
 }
 
 export default function LiveMetrics() {
@@ -120,7 +148,7 @@ export default function LiveMetrics() {
     refetch: refetchLatestBlocks,
   } = useApiData<LatestBlocksResponse>(fetchLatestBlocks, undefined, network);
 
-  // Refresh the rolling sample used for Top L2 whenever a new block lands.
+  // Refresh the rolling sample used for Top User whenever a new block lands.
   // The Latest Block card reads `newBlockEvent` directly (below) rather than
   // relying on this refetch — fetchApi dedupes in-flight GETs, so an
   // in-progress call started before the event would otherwise satisfy the
@@ -160,8 +188,8 @@ export default function LiveMetrics() {
     return liveBlock;
   }, [newBlockEvent, fetchedLatest]);
 
-  const topL2 = useMemo(
-    () => computeTopL2(latestBlocks?.data ?? []),
+  const topUser = useMemo(
+    () => computeTopUser(latestBlocks?.data ?? []),
     [latestBlocks]
   );
 
@@ -169,7 +197,7 @@ export default function LiveMetrics() {
     stats: StatsResponse,
     window: RollingWindowDataPoint,
     block: Block | undefined,
-    l2: TopL2Stat | null,
+    user: TopUserStat | null,
   ) => [
     {
       title: 'Avg Base Fee',
@@ -195,13 +223,15 @@ export default function LiveMetrics() {
       icon: 'fa-regular fa-hourglass-half',
     },
     {
-      title: 'Top L2',
-      value: l2 ? l2.name : '—',
+      title: 'Top User',
+      value: user ? user.name : '—',
       trend: 'neutral' as const,
-      description: l2
-        ? `${l2.share.toFixed(0)}% of last ${l2.blocksSampled} blocks`
-        : 'No attributed blobs yet',
-      icon: 'fa-regular fa-layer-group',
+      description: user
+        ? `${user.share.toFixed(0)}% of last ${user.blocksSampled} blocks`
+        : 'No user data yet',
+      icon: 'fa-regular fa-user',
+      href: user ? `/user/${encodeURIComponent(user.address)}` : undefined,
+      ariaLabel: user ? `View user ${user.name}` : undefined,
     },
   ];
 
@@ -232,7 +262,7 @@ export default function LiveMetrics() {
       >
         {displayStats && selectedWindow && (
           <div className="grid grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {getMetrics(displayStats, selectedWindow, latestBlock, topL2).map((metric, index) => (
+            {getMetrics(displayStats, selectedWindow, latestBlock, topUser).map((metric, index) => (
               <MetricCard
                 key={index}
                 title={metric.title}
@@ -240,6 +270,8 @@ export default function LiveMetrics() {
                 trend={metric.trend}
                 description={metric.description}
                 icon={metric.icon}
+                href={metric.href}
+                ariaLabel={metric.ariaLabel}
               />
             ))}
           </div>
@@ -248,7 +280,7 @@ export default function LiveMetrics() {
 
       {haveHeadline && blocksError && (
         <p className="mt-3 text-xs text-red-300">
-          Latest Block and Top L2 data unavailable:{' '}
+          Latest Block and Top User data unavailable:{' '}
           {blocksError.message}
           {latestBlocks ? '. Showing the last successful sample.' : '.'}
         </p>

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from 'react';
+import Link from 'next/link';
 
 interface MetricCardProps {
   title: string;
@@ -8,35 +9,63 @@ interface MetricCardProps {
   trend?: 'up' | 'down' | 'neutral';
   description?: string;
   icon?: string;
+  href?: string;
+  ariaLabel?: string;
 }
 
-export default function MetricCard({ title, value, trend = 'neutral', description, icon }: MetricCardProps) {
+export default function MetricCard({
+  title,
+  value,
+  trend = 'neutral',
+  description,
+  icon,
+  href,
+  ariaLabel,
+}: MetricCardProps) {
+  const cardClassName = "relative block rounded-lg p-4 shadow-md transition-all hover:shadow-lg border border-divider h-full";
+  const cardStyle = {
+    background: `url('/images/subtle-pattern.png') repeat, #141519`,
+  };
+  const cardContent = (
+    <>
+      <div className="flex justify-between items-start mb-2">
+        <h3 className="text-[#b8bdc7] font-medium text-xs uppercase tracking-wider flex items-center mb-1">
+          {icon && <i className={`${icon} text-blue mr-2`} aria-hidden="true"></i>}
+          {title}
+        </h3>
+        {trend === 'up' && (
+          <i className="fa-regular fa-arrow-up-right text-[#b8bdc7]" aria-hidden="true"></i>
+        )}
+        {trend === 'down' && (
+          <i className="fa-regular fa-arrow-down-right text-[#b8bdc7]" aria-hidden="true"></i>
+        )}
+      </div>
+      <div>
+        <p className="truncate text-2xl font-windsor-bold text-white" title={value}>{value}</p>
+        {description && <p className="text-xs mt-1 text-[#b8bdc7]">{description}</p>}
+      </div>
+    </>
+  );
+
   return (
     <div className="relative h-full">
       {/* Blue outer glow/border */}
       <div className="absolute -inset-[2px] rounded-lg bg-blue/40"></div>
-      
-      <div className="relative rounded-lg p-4 shadow-md transition-all hover:shadow-lg border border-divider h-full" 
-           style={{ 
-             background: `url('/images/subtle-pattern.png') repeat, #141519` 
-           }}>
-        <div className="flex justify-between items-start mb-2">
-          <h3 className="text-[#b8bdc7] font-medium text-xs uppercase tracking-wider flex items-center mb-1">
-            {icon && <i className={`${icon} text-blue mr-2`} aria-hidden="true"></i>}
-            {title}
-          </h3>
-          {trend === 'up' && (
-            <i className="fa-regular fa-arrow-up-right text-[#b8bdc7]" aria-hidden="true"></i>
-          )}
-          {trend === 'down' && (
-            <i className="fa-regular fa-arrow-down-right text-[#b8bdc7]" aria-hidden="true"></i>
-          )}
+
+      {href ? (
+        <Link
+          href={href}
+          aria-label={ariaLabel || `View ${title}`}
+          className={`${cardClassName} focus:outline-none focus:ring-2 focus:ring-blue focus:ring-offset-2 focus:ring-offset-[#0b0c10]`}
+          style={cardStyle}
+        >
+          {cardContent}
+        </Link>
+      ) : (
+        <div className={cardClassName} style={cardStyle}>
+          {cardContent}
         </div>
-        <div>
-          <p className="text-2xl font-windsor-bold text-white">{value}</p>
-          {description && <p className="text-xs mt-1 text-[#b8bdc7]">{description}</p>}
-        </div>
-      </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Replace the live metrics "Top L2" card with "Top User".
- Aggregate the metric by blob sender address, showing the attributed name when available and a compact address otherwise.
- Make the Top User metric card link to the existing `/user/[address]` page.

## Impact

Users can now jump directly from the live dashboard metric to the dominant sender's user detail page instead of seeing an L2-only label.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test`
