### PR TITLE
feat: add enlarged chart views

### DIFF
--- a/src/app/charts/[chart]/page.tsx
+++ b/src/app/charts/[chart]/page.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import React from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+import DataStateWrapper from '@/components/DataStateWrapper';
+import { useChartData } from '@/hooks/useChartData';
+import { CHART_CARD_CLASS } from '@/constants/chartTheme';
+import {
+  CHART_VIEWS,
+  ChartView,
+  getChartView,
+} from '@/components/charts/chartViews';
+import type { ChartDataset } from '@/types';
+
+function ChartTabs({ activeId }: { activeId?: string }) {
+  return (
+    <nav aria-label="Charts" className="flex flex-wrap gap-2">
+      {CHART_VIEWS.map((chartView) => {
+        const isActive = chartView.id === activeId;
+
+        return (
+          <Link
+            key={chartView.id}
+            href={`/charts/${chartView.id}`}
+            className={`rounded-md border px-3 py-1.5 text-sm transition-colors ${isActive
+              ? 'border-blue bg-blue/20 text-white'
+              : 'border-divider bg-[#1d1f23] text-bodyText hover:bg-[#252936] hover:text-white'
+              }`}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            {chartView.shortTitle}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+function EmptyChartState() {
+  return (
+    <div className="flex h-full min-h-[260px] items-center justify-center text-center">
+      <div>
+        <div className="text-lg font-medium text-white">No chart data available</div>
+        <div className="mt-1 text-sm text-[#6e7687]">
+          The selected network has not returned data for this view.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function getCoverageLabel(view: ChartView, chartData: ChartDataset): string {
+  if (view.id === 'rolling-market-stats') {
+    return chartData.rollingCoverageLabel;
+  }
+
+  return chartData.blockCoverageLabel;
+}
+
+function ChartDetail({ view }: { view: ChartView }) {
+  const { chartData, isLoading, error } = useChartData();
+
+  const loadingComponent = (
+    <div className={CHART_CARD_CLASS}>
+      <div className="mb-5 flex items-start justify-between gap-4">
+        <div className="space-y-2">
+          <div className="h-7 w-72 max-w-full rounded bg-[#202538] animate-pulse" />
+          <div className="h-4 w-96 max-w-full rounded bg-[#202538] animate-pulse" />
+        </div>
+        <div className="h-8 w-24 rounded bg-[#202538] animate-pulse" />
+      </div>
+      <div className="h-[62vh] min-h-[360px] max-h-[720px] rounded bg-[#202538] animate-pulse" />
+    </div>
+  );
+
+  return (
+    <DataStateWrapper isLoading={isLoading} error={error} loadingComponent={loadingComponent}>
+      {chartData && (
+        <div className={CHART_CARD_CLASS}>
+          <div className="relative z-10 mb-5 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div>
+              <h2 className="text-xl font-medium text-white">{view.title}</h2>
+              <p className="mt-1 text-sm text-[#6e7687]">
+                {getCoverageLabel(view, chartData)}
+              </p>
+            </div>
+            <Link
+              href="/#data-trends"
+              className="inline-flex h-8 items-center justify-center gap-2 self-start rounded-md border border-divider bg-[#1d1f23] px-3 text-sm text-bodyText transition-colors hover:bg-[#252936] hover:text-white focus:outline-none focus:ring-2 focus:ring-blue/60"
+            >
+              <i className="fa-regular fa-compress" aria-hidden="true" />
+              Dashboard
+            </Link>
+          </div>
+          <div className={view.detailFrameClassName}>
+            {view.getPointCount(chartData) > 0 ? view.render(chartData) : <EmptyChartState />}
+          </div>
+        </div>
+      )}
+    </DataStateWrapper>
+  );
+}
+
+function UnknownChart({ chartId }: { chartId: string | undefined }) {
+  return (
+    <div className="rounded-lg border border-divider bg-[#161a29]/80 p-6">
+      <h1 className="text-2xl font-windsor-bold text-white mb-2">Chart not found</h1>
+      <p className="text-bodyText text-sm mb-5">
+        {chartId ? `There is no chart named "${chartId}".` : 'No chart was selected.'}
+      </p>
+      <ChartTabs />
+    </div>
+  );
+}
+
+export default function ChartDetailPage() {
+  const params = useParams();
+  const chartId = params.chart as string | undefined;
+  const view = getChartView(chartId);
+
+  return (
+    <main className="min-h-screen bg-background bg-grid-pattern bg-grid-size">
+      <Header />
+      <div className="container mx-auto px-4 py-8 max-w-[1600px]">
+        <Link
+          href="/#data-trends"
+          className="text-blue hover:underline text-sm mb-6 inline-flex items-center gap-2"
+        >
+          <i className="fa-regular fa-arrow-left" aria-hidden="true" />
+          Back to Dashboard
+        </Link>
+
+        {view ? (
+          <section>
+            <div className="mb-6 flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
+              <div>
+                <h1 className="text-3xl font-windsor-bold text-white mb-2">
+                  {view.shortTitle}
+                </h1>
+                <p className="max-w-2xl text-sm text-bodyText">
+                  {view.description}
+                </p>
+              </div>
+              <ChartTabs activeId={view.id} />
+            </div>
+
+            <ChartDetail view={view} />
+          </section>
+        ) : (
+          <UnknownChart chartId={chartId} />
+        )}
+      </div>
+      <Footer />
+    </main>
+  );
+}

--- a/src/components/MetricsCharts.tsx
+++ b/src/components/MetricsCharts.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import React from 'react';
+import Link from 'next/link';
 import { useChartData } from '../hooks/useChartData';
 import DataStateWrapper from './DataStateWrapper';
-import BaseFeeChart from './charts/BaseFeeChart';
-import GasUtilizationChart from './charts/GasUtilizationChart';
 import FeeIndicators from './charts/FeeIndicators';
-import RollingWindowStats from './charts/RollingWindowStats';
+import { CHART_VIEWS } from './charts/chartViews';
 import { CHART_CARD_CLASS } from '../constants/chartTheme';
 
 export default function MetricsCharts() {
@@ -24,7 +23,7 @@ export default function MetricsCharts() {
   );
 
   return (
-    <section>
+    <section id="data-trends" className="scroll-mt-20">
       <h2 className="text-2xl font-windsor-bold text-white mb-3">Data Trends</h2>
       <DataStateWrapper isLoading={isLoading} error={error} loadingComponent={loadingComponent}>
         {chartData && (
@@ -35,38 +34,26 @@ export default function MetricsCharts() {
               selectedWindow={chartData.selectedWindow}
             />
 
-            {/* Base Fee over Recent Blocks */}
-            <div className={CHART_CARD_CLASS}>
-              <h3 className="text-md font-medium mb-4 text-white">
-                Base Fee over Recent Blocks (Gwei)
-              </h3>
-              <div className="h-56 relative">
-                <BaseFeeChart data={chartData.baseFee} />
+            {CHART_VIEWS.map((view) => (
+              <div key={view.id} className={CHART_CARD_CLASS}>
+                <div className="flex items-start justify-between gap-3 mb-4">
+                  <h3 className="text-md font-medium text-white">
+                    {view.title}
+                  </h3>
+                  <Link
+                    href={`/charts/${view.id}`}
+                    className="relative z-10 flex h-8 w-8 flex-none items-center justify-center rounded-md border border-divider bg-[#1d1f23] text-blue transition-colors hover:bg-[#252936] hover:text-lightBlue focus:outline-none focus:ring-2 focus:ring-blue/60"
+                    aria-label={`Open ${view.title} enlarged`}
+                    title="Enlarge graph"
+                  >
+                    <i className="fa-regular fa-expand" aria-hidden="true" />
+                  </Link>
+                </div>
+                <div className={view.dashboardFrameClassName}>
+                  {view.render(chartData)}
+                </div>
               </div>
-            </div>
-
-            {/* Blob Gas Utilization */}
-            <div className={CHART_CARD_CLASS}>
-              <h3 className="text-md font-medium mb-4 text-white">
-                Blob Gas Utilization vs Current Target
-              </h3>
-              <div className="h-56 relative">
-                <GasUtilizationChart data={chartData.gasUtilization} />
-              </div>
-            </div>
-
-            {/* Rolling Window Stats */}
-            <div className={CHART_CARD_CLASS}>
-              <h3 className="text-md font-medium mb-4 text-white">
-                Rolling Market Stats
-              </h3>
-              <div className="relative">
-                <RollingWindowStats
-                  windows={chartData.rollingWindows}
-                  selectedWindow={chartData.selectedWindow}
-                />
-              </div>
-            </div>
+            ))}
 
             {/* Data coverage note */}
             <p className="text-xs text-[#6e7687] text-center">

--- a/src/components/charts/chartViews.tsx
+++ b/src/components/charts/chartViews.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import React from 'react';
+import type { ChartDataset } from '../../types';
+import BaseFeeChart from './BaseFeeChart';
+import GasUtilizationChart from './GasUtilizationChart';
+import RollingWindowStats from './RollingWindowStats';
+
+export const CHART_VIEW_IDS = [
+  'base-fee',
+  'gas-utilization',
+  'rolling-market-stats',
+] as const;
+
+export type ChartViewId = (typeof CHART_VIEW_IDS)[number];
+
+export interface ChartView {
+  id: ChartViewId;
+  title: string;
+  shortTitle: string;
+  description: string;
+  dashboardFrameClassName: string;
+  detailFrameClassName: string;
+  getPointCount: (chartData: ChartDataset) => number;
+  render: (chartData: ChartDataset) => React.ReactNode;
+}
+
+export const CHART_VIEWS: readonly ChartView[] = [
+  {
+    id: 'base-fee',
+    title: 'Base Fee over Recent Blocks (Gwei)',
+    shortTitle: 'Base Fee',
+    description: 'Blob base fee trend across the most recent indexed blocks.',
+    dashboardFrameClassName: 'h-56 relative',
+    detailFrameClassName: 'h-[62vh] min-h-[360px] max-h-[720px] relative',
+    getPointCount: (chartData) => chartData.baseFee.length,
+    render: (chartData) => <BaseFeeChart data={chartData.baseFee} />,
+  },
+  {
+    id: 'gas-utilization',
+    title: 'Blob Gas Utilization vs Current Target',
+    shortTitle: 'Gas Utilization',
+    description: 'Blob gas used per block against the current target.',
+    dashboardFrameClassName: 'h-56 relative',
+    detailFrameClassName: 'h-[62vh] min-h-[360px] max-h-[720px] relative',
+    getPointCount: (chartData) => chartData.gasUtilization.length,
+    render: (chartData) => <GasUtilizationChart data={chartData.gasUtilization} />,
+  },
+  {
+    id: 'rolling-market-stats',
+    title: 'Rolling Market Stats',
+    shortTitle: 'Rolling Stats',
+    description: 'Windowed fee, utilization, cost, and sender totals.',
+    dashboardFrameClassName: 'relative',
+    detailFrameClassName: 'relative',
+    getPointCount: (chartData) => chartData.rollingWindows.length,
+    render: (chartData) => (
+      <RollingWindowStats
+        windows={chartData.rollingWindows}
+        selectedWindow={chartData.selectedWindow}
+      />
+    ),
+  },
+];
+
+export function getChartView(chartId: string | undefined): ChartView | null {
+  return CHART_VIEWS.find((view) => view.id === chartId) ?? null;
+}


### PR DESCRIPTION
## Summary

- Add expand controls to the dashboard chart cards.
- Add dedicated enlarged chart routes for base fee, gas utilization, and rolling market stats.
- Share chart metadata/rendering through a small chart view registry so dashboard and detail pages stay aligned.

## Impact

Users can open each graph in a larger focused view with chart tabs for switching between views, then return to the dashboard data trends section.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- Verified the expand flow in the in-app browser; chart routes rendered correctly.