### PR TITLE
fix: prevent blocks row auto-expand

### DIFF
--- a/src/components/LatestBlocksTable.test.tsx
+++ b/src/components/LatestBlocksTable.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { DEFAULT_NETWORK } from '../constants';
+import { useLatestBlobEvent } from '../contexts/LiveDataContext';
+import { useApiData } from '../hooks/useApiData';
+import { useNetwork } from '../hooks/useNetwork';
+import { Block, BlobResponse, LatestBlocksResponse } from '../types';
+import LatestBlocksTable from './LatestBlocksTable';
+
+vi.mock('next/image', () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => React.createElement('img', props),
+}));
+
+vi.mock('../hooks/useApiData', () => ({
+  useApiData: vi.fn(),
+}));
+
+vi.mock('../hooks/useNetwork', () => ({
+  useNetwork: vi.fn(),
+}));
+
+vi.mock('../contexts/LiveDataContext', () => ({
+  useLatestBlobEvent: vi.fn(),
+}));
+
+vi.mock('../hooks/useFlipRows', () => ({
+  useFlipRows: vi.fn(),
+}));
+
+const blob: BlobResponse = {
+  network_id: 1,
+  network_name: 'mainnet',
+  block_number: 200,
+  blob_index: 0,
+  tx_hash: '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+  from_address: '0x1234567890abcdef1234567890abcdef12345678',
+  blob_size_bytes: 131072,
+  base_fee_per_blob_gas: '1000000000',
+  base_fee_per_blob_gas_gwei: '1',
+  tip_per_blob_gas: '100000000',
+  tip_per_blob_gas_gwei: '0.1',
+  total_cost_eth: '0.001',
+  timestamp: '2026-01-01T00:00:00.000Z',
+  confirmed: true,
+  user_attribution: 'Base',
+  max_fee_per_blob_gas: '2000000000',
+  max_fee_per_blob_gas_gwei: '2',
+  blob_gas_used: 131072,
+  realized_cost_wei: '1000000000000000',
+  max_cost_wei: '2000000000000000',
+};
+
+function makeBlock(id: number, blobs: BlobResponse[] = []): Block {
+  return {
+    id,
+    number: id.toString(),
+    blobCount: blobs.length,
+    blobGasUsed: blobs.length * 131072,
+    blobGasTarget: 393216,
+    blobGasLimit: 786432,
+    targetBlobs: 3,
+    maxBlobs: 6,
+    availableBlobs: 6 - blobs.length,
+    baseFeeGwei: '1',
+    utilizationPercent: blobs.length === 0 ? 0 : 16.67,
+    isFull: false,
+    isAboveTarget: false,
+    timestamp: '2026-01-01T00:00:00.000Z',
+    attribution: blobs.length > 0 ? ['Base'] : [],
+    blobs,
+  };
+}
+
+describe('LatestBlocksTable', () => {
+  beforeEach(() => {
+    vi.mocked(useNetwork).mockReturnValue({
+      selectedNetwork: DEFAULT_NETWORK,
+      setSelectedNetwork: vi.fn(),
+      networkOptions: [DEFAULT_NETWORK],
+    });
+    vi.mocked(useLatestBlobEvent).mockReturnValue(null);
+    vi.mocked(useApiData<LatestBlocksResponse>).mockReturnValue({
+      data: {
+        data: [
+          makeBlock(201),
+          makeBlock(200, [blob]),
+        ],
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  it('does not auto-expand a block row on initial load', () => {
+    render(<LatestBlocksTable />);
+
+    expect(screen.queryByText('Blob details')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'View blob details for block 200' }));
+
+    expect(screen.getByText('Blob details')).toBeInTheDocument();
+    expect(screen.getByText('Blob #0')).toBeInTheDocument();
+  });
+});

--- a/src/components/LatestBlocksTable.tsx
+++ b/src/components/LatestBlocksTable.tsx
@@ -162,7 +162,6 @@ export default function LatestBlocksTable() {
   const liveBlockEvent = useLatestBlobEvent('new_block');
   const [expandedBlockId, setExpandedBlockId] = React.useState<number | null>(null);
   const [page, setPage] = React.useState(1);
-  const hasUserSelectedBlockRef = React.useRef(false);
 
   const { data, isLoading, error } = useApiData<LatestBlocksResponse>(
     () => api.getLatestBlocks(BLOCKS_PAGE_LIMIT, selectedNetwork.apiParam),
@@ -192,7 +191,6 @@ export default function LatestBlocksTable() {
   }, [mergedBlocks, pageStart]);
 
   const toggleBlock = React.useCallback((blockId: number) => {
-    hasUserSelectedBlockRef.current = true;
     setExpandedBlockId((currentBlockId) => currentBlockId === blockId ? null : blockId);
   }, []);
 
@@ -207,26 +205,15 @@ export default function LatestBlocksTable() {
   }, [toggleBlock]);
 
   React.useEffect(() => {
-    hasUserSelectedBlockRef.current = false;
     setExpandedBlockId(null);
     setPage(1);
   }, [selectedNetwork.apiParam]);
-
-  React.useEffect(() => {
-    if (!displayData || hasUserSelectedBlockRef.current) return;
-
-    const defaultExpandedBlock = displayData.data.find((block) => block.blobs.length > 0) || displayData.data[0];
-    if (defaultExpandedBlock && expandedBlockId !== defaultExpandedBlock.id) {
-      setExpandedBlockId(defaultExpandedBlock.id);
-    }
-  }, [displayData, expandedBlockId]);
 
   React.useEffect(() => {
     if (expandedBlockId === null || !displayData) return;
 
     const expandedBlockExists = displayData.data.some((block) => block.id === expandedBlockId);
     if (!expandedBlockExists) {
-      hasUserSelectedBlockRef.current = false;
       setExpandedBlockId(null);
     }
   }, [displayData, expandedBlockId]);


### PR DESCRIPTION
## Summary

- Remove the effect that auto-selected the first block with blobs on the `/blocks` page.
- Keep user-triggered row expansion and stale expanded-row cleanup behavior intact.
- Add a regression test proving initial render starts with no expanded details row and clicking still expands a row.

## Why

The `/blocks` table was automatically expanding a row after data loaded, often appearing as the second row because it selected the first block with blob details. Rows should start collapsed on page load so users opt into the blob breakdown.

## Validation

- `npm test`
- `npm run lint`
- `npm run typecheck`