### PR TITLE
fix: include period in avg base fee panel

### DIFF
--- a/src/components/LiveMetrics.tsx
+++ b/src/components/LiveMetrics.tsx
@@ -204,7 +204,7 @@ export default function LiveMetrics() {
     user: TopUserStat | null,
   ) => [
     {
-      title: 'Avg Base Fee',
+      title: `Avg Base Fee (${window.label})`,
       value: formatGwei(window.averageBaseFeeGwei),
       trend: 'neutral' as const,
       description: `Median ${formatGwei(window.medianBaseFeeGwei)} · p95 ${formatGwei(window.p95BaseFeeGwei)}`,


### PR DESCRIPTION
## Summary
- Show the selected rolling window in the Avg Base Fee panel title.
- Keep the existing median and p95 details unchanged.

## Impact
Users can now see which time period the average base fee value represents as they change the dashboard time selector.

## Validation
- `npm run lint`
- `npm run typecheck`
