### PR TITLE
fix: smooth table row animations

### DIFF
--- a/src/hooks/useFlipRows.test.tsx
+++ b/src/hooks/useFlipRows.test.tsx
@@ -144,13 +144,23 @@ describe('useFlipRows', () => {
 
     const enterAnim = animations[0];
     const enterFrames = enterAnim.keyframes as Keyframe[];
-    expect(enterFrames[0]).toMatchObject({ opacity: 0, transform: 'translateY(-16px)' });
-    expect(enterFrames[1]).toMatchObject({ opacity: 1, transform: 'translateY(0)' });
+    expect(enterFrames[0]).toMatchObject({ opacity: 0, transform: 'translateY(-10px)' });
+    expect(enterFrames[1]).toMatchObject({ opacity: 0.65, transform: 'translateY(-3px)' });
+    expect(enterFrames[2]).toMatchObject({ opacity: 1, transform: 'translateY(0)' });
+    expect(enterAnim.options).toMatchObject({
+      duration: 1400,
+      easing: 'cubic-bezier(0.22, 0.61, 0.36, 1)',
+      fill: 'backwards',
+    });
 
     const flipAnim = animations[1];
     const flipFrames = flipAnim.keyframes as Keyframe[];
     expect(flipFrames[0]).toMatchObject({ transform: 'translateY(-30px)' });
     expect(flipFrames[1]).toMatchObject({ transform: 'translateY(0)' });
+    expect(flipAnim.options).toMatchObject({
+      duration: 950,
+      easing: 'cubic-bezier(0.22, 0.61, 0.36, 1)',
+    });
   });
 
   it('finishes prior FLIP animations before re-measuring', () => {

--- a/src/hooks/useFlipRows.ts
+++ b/src/hooks/useFlipRows.ts
@@ -2,8 +2,9 @@
 
 import React from 'react';
 
-const ANIMATION_DURATION = 450;
-const ANIMATION_EASING = 'cubic-bezier(0.16, 1, 0.3, 1)';
+const ROW_ENTER_ANIMATION_DURATION = 1400;
+const ROW_MOVE_ANIMATION_DURATION = 950;
+const ROW_ANIMATION_EASING = 'cubic-bezier(0.22, 0.61, 0.36, 1)';
 
 function prefersReducedMotion(): boolean {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
@@ -110,10 +111,15 @@ export function useFlipRows(
         nextAnimations.push(
           row.animate(
             [
-              { opacity: 0, transform: 'translateY(-16px)' },
+              { opacity: 0, transform: 'translateY(-10px)' },
+              { opacity: 0.65, transform: 'translateY(-3px)' },
               { opacity: 1, transform: 'translateY(0)' },
             ],
-            { duration: ANIMATION_DURATION, easing: ANIMATION_EASING, fill: 'backwards' }
+            {
+              duration: ROW_ENTER_ANIMATION_DURATION,
+              easing: ROW_ANIMATION_EASING,
+              fill: 'backwards',
+            }
           )
         );
         return;
@@ -127,7 +133,7 @@ export function useFlipRows(
               { transform: `translateY(${delta}px)` },
               { transform: 'translateY(0)' },
             ],
-            { duration: ANIMATION_DURATION, easing: ANIMATION_EASING }
+            { duration: ROW_MOVE_ANIMATION_DURATION, easing: ROW_ANIMATION_EASING }
           )
         );
       }


### PR DESCRIPTION
## Summary

- Slow down the new-row entry animation so live table updates feel calmer.
- Use a softer easing curve and smaller initial offset for smoother row movement.
- Add assertions for the new animation timing and keyframes.

## Validation

- `npm test`
- `npm run lint`
- `npm run typecheck`
- Browser smoke check at `http://localhost:3001`