### PR TITLE
fix: populate recent block fees from websocket

### DIFF
--- a/src/app/user/[address]/page.tsx
+++ b/src/app/user/[address]/page.tsx
@@ -69,7 +69,7 @@ function BlobTable({ blobs, showBlock }: { blobs: BlobResponse[]; showBlock: boo
             const maxFee = formatBlobFee(blob.max_fee_per_blob_gas_gwei, blob.max_fee_per_blob_gas);
             const realizedCost = blob.realized_cost_wei
               ? formatBlobWeiCost(blob.realized_cost_wei)
-              : formatBlobTotalCost(blob.total_cost_eth);
+              : formatBlobTotalCost(blob.total_cost_wei || blob.total_cost_eth);
             const maxCost = formatBlobWeiCost(blob.max_cost_wei);
             const headroom = formatFeeHeadroom(blob.fee_cap_headroom_percent);
 
@@ -244,7 +244,7 @@ export default function UserDetailPage() {
                 </div>
                 <div className="bg-gradient-to-b from-[#22252c] to-[#16171b] border border-divider rounded-lg p-4">
                   <div className="text-xs text-[#6e7787] uppercase tracking-wider mb-1">Total Cost</div>
-                  <div className="text-xl text-white font-medium">{formatCostEthOrWei(user.total_cost_eth)}</div>
+                  <div className="text-xl text-white font-medium">{formatCostEthOrWei(user.total_cost_wei || user.total_cost_eth)}</div>
                 </div>
                 <div className="bg-gradient-to-b from-[#22252c] to-[#16171b] border border-divider rounded-lg p-4">
                   <div className="text-xs text-[#6e7787] uppercase tracking-wider mb-1">Last Active</div>

--- a/src/components/BlobDetailsContent.tsx
+++ b/src/components/BlobDetailsContent.tsx
@@ -85,7 +85,7 @@ export function BlobDetailsContent({ block }: { block: Block }) {
           {block.blobs.map((blob) => {
             const realizedCost = blob.realized_cost_wei
               ? formatBlobWeiCost(blob.realized_cost_wei)
-              : formatBlobTotalCost(blob.total_cost_eth);
+              : formatBlobTotalCost(blob.total_cost_wei || blob.total_cost_eth);
             const maxCost = formatBlobWeiCost(blob.max_cost_wei);
             const baseFee = formatBlobFee(blob.base_fee_per_blob_gas_gwei, blob.base_fee_per_blob_gas);
             const tip = formatBlobFee(blob.tip_per_blob_gas_gwei, blob.tip_per_blob_gas);

--- a/src/components/LatestBlocksTable.test.tsx
+++ b/src/components/LatestBlocksTable.test.tsx
@@ -102,4 +102,26 @@ describe('LatestBlocksTable', () => {
     expect(screen.getByText('Blob details')).toBeInTheDocument();
     expect(screen.getByText('Blob #0')).toBeInTheDocument();
   });
+
+  it('falls back to total_cost_eth when total_cost_wei is invalid', () => {
+    vi.mocked(useApiData<LatestBlocksResponse>).mockReturnValue({
+      data: {
+        data: [
+          makeBlock(200, [{
+            ...blob,
+            realized_cost_wei: undefined,
+            total_cost_wei: 'not-wei',
+            total_cost_eth: '0.001',
+          }]),
+        ],
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<LatestBlocksTable />);
+
+    expect(screen.getAllByText('0.001 ETH')).toHaveLength(2);
+  });
 });

--- a/src/components/LatestBlocksTable.tsx
+++ b/src/components/LatestBlocksTable.tsx
@@ -65,6 +65,9 @@ function getBlobPaidWei(blob: BlobResponse): bigint | null {
   const realizedCost = parseWeiString(blob.realized_cost_wei);
   if (realizedCost !== null) return realizedCost;
 
+  const totalCostWei = parseWeiString(blob.total_cost_wei);
+  if (totalCostWei !== null) return totalCostWei;
+
   if (!blob.total_cost_eth) return null;
   if (blob.total_cost_eth.includes('.')) return parseEthToWei(blob.total_cost_eth);
   return parseWeiString(blob.total_cost_eth);

--- a/src/components/MempoolBlobDetailsModal.tsx
+++ b/src/components/MempoolBlobDetailsModal.tsx
@@ -118,7 +118,7 @@ export default function MempoolBlobDetailsModal({
             <DetailItem label="Base Fee" value={safeFormatWei(blob.base_fee_per_blob_gas)} />
             <DetailItem label="Tip" value={safeFormatWei(blob.tip_per_blob_gas)} />
             <DetailItem label="Max Fee" value={safeFormatWei(blob.max_fee_per_blob_gas)} />
-            <DetailItem label="Estimated Cost" value={safeFormatCost(blob.total_cost_eth)} />
+            <DetailItem label="Estimated Cost" value={safeFormatCost(blob.total_cost_wei || blob.total_cost_eth)} />
             <DetailItem label="First Seen" value={formatTimestamp(blob.timestamp)} full />
           </dl>
         </div>

--- a/src/components/RecentBlocksPanel.test.tsx
+++ b/src/components/RecentBlocksPanel.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { DEFAULT_NETWORK } from '../constants';
-import { useLatestBlobEvent } from '../contexts/LiveDataContext';
+import { LiveDataProvider } from '../contexts/LiveDataContext';
 import { useApiData } from '../hooks/useApiData';
 import { useNetwork } from '../hooks/useNetwork';
 import { BlobResponse, Block, LatestBlocksResponse } from '../types';
@@ -15,9 +15,34 @@ vi.mock('../hooks/useNetwork', () => ({
   useNetwork: vi.fn(),
 }));
 
-vi.mock('../contexts/LiveDataContext', () => ({
-  useLatestBlobEvent: vi.fn(),
-}));
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  readyState = 0;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  send() {}
+
+  close() {
+    this.readyState = 3;
+  }
+
+  open() {
+    this.readyState = 1;
+    this.onopen?.(new Event('open'));
+  }
+
+  receive(data: string) {
+    this.onmessage?.(new MessageEvent('message', { data }));
+  }
+}
 
 function makeBlock(overrides: Partial<Block>): Block {
   return {
@@ -41,32 +66,99 @@ function makeBlock(overrides: Partial<Block>): Block {
   };
 }
 
-const liveBlob: BlobResponse = {
-  network_id: 1,
-  network_name: 'mainnet',
-  block_number: 202,
-  blob_index: 0,
-  tx_hash: '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
-  from_address: '0x1234567890abcdef1234567890abcdef12345678',
-  blob_size_bytes: 131072,
-  base_fee_per_blob_gas: '1000000000',
-  base_fee_per_blob_gas_gwei: '1',
-  tip_per_blob_gas: '0',
-  total_cost_eth: '0.001',
-  timestamp: '2026-01-01T00:00:12.000Z',
-  confirmed: true,
-  user_attribution: 'Base',
-  blob_gas_used: 655360,
-};
+function makeBlob(
+  blockNumber: number,
+  blobIndex: number,
+  overrides: Partial<BlobResponse> = {}
+): BlobResponse {
+  return {
+    network_id: 1,
+    network_name: 'mainnet',
+    block_number: blockNumber,
+    blob_index: blobIndex,
+    tx_hash: `0x${blockNumber.toString(16).padStart(64, '0')}${blobIndex}`,
+    from_address: '0x1234567890abcdef1234567890abcdef12345678',
+    blob_size_bytes: 131072,
+    base_fee_per_blob_gas: '1000000000',
+    base_fee_per_blob_gas_gwei: '1',
+    tip_per_blob_gas: '0',
+    total_cost_eth: '0.001',
+    timestamp: `2026-01-01T00:00:0${blobIndex}.000Z`,
+    confirmed: true,
+    user_attribution: 'Base',
+    blob_gas_used: 131072,
+    ...overrides,
+  };
+}
+
+function makeNewBlockMessage(blockNumber: number, blobCount: number): string {
+  return JSON.stringify({
+    type: 'new_block',
+    data: {
+      block_number: blockNumber,
+      blob_count: blobCount,
+      timestamp: '2026-01-01T00:00:00.000Z',
+      blobs: Array.from({ length: blobCount }, (_, index) => makeBlob(blockNumber, index)),
+      pricing: {
+        block_number: blockNumber,
+        block_timestamp: '2026-01-01T00:00:00.000Z',
+        blob_count: blobCount,
+        blob_gas_used: blobCount * 131072,
+        blob_gas_target: 393216,
+        blob_gas_limit: 786432,
+        excess_blob_gas: 0,
+        blob_base_fee: '250000000',
+        blob_base_fee_gwei: '0.25',
+        utilization_ratio: (blobCount / 6).toString(),
+        blob_params_target: 3,
+        blob_params_max: 6,
+        target_blobs: 3,
+        max_blobs: 6,
+        available_blobs: 6 - blobCount,
+        utilization_percent: (blobCount / 6) * 100,
+        is_full: blobCount === 6,
+        is_above_target: blobCount > 3,
+        update_fraction: 3338477,
+      },
+    },
+  });
+}
+
+function makeLegacyNewBlockMessage(blockNumber: number, blob: BlobResponse): string {
+  return JSON.stringify({
+    type: 'new_block',
+    data: {
+      block_number: blockNumber,
+      blob_count: 1,
+      timestamp: blob.timestamp,
+      blobs: [blob],
+    },
+  });
+}
+
+function renderRecentBlocksPanel() {
+  return render(
+    <LiveDataProvider network={DEFAULT_NETWORK.apiParam}>
+      <RecentBlocksPanel />
+    </LiveDataProvider>
+  );
+}
 
 describe('RecentBlocksPanel', () => {
   beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', MockWebSocket);
     vi.mocked(useNetwork).mockReturnValue({
       selectedNetwork: DEFAULT_NETWORK,
       setSelectedNetwork: vi.fn(),
       networkOptions: [DEFAULT_NETWORK],
     });
-    vi.mocked(useLatestBlobEvent).mockReturnValue(null);
+    vi.mocked(useApiData<LatestBlocksResponse>).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    });
   });
 
   it('derives blob usage and target state from blob gas for matching labels and colors', () => {
@@ -90,7 +182,7 @@ describe('RecentBlocksPanel', () => {
       refetch: vi.fn(),
     });
 
-    render(<RecentBlocksPanel />);
+    renderRecentBlocksPanel();
 
     expect(screen.getByText('5/21 blobs')).toBeInTheDocument();
     expect(screen.getByText('24%')).toBeInTheDocument();
@@ -116,16 +208,7 @@ describe('RecentBlocksPanel', () => {
     });
   });
 
-  it('adds a target marker to live blocks by reusing fetched capacity params', () => {
-    vi.mocked(useLatestBlobEvent).mockReturnValue({
-      type: 'new_block',
-      data: {
-        block_number: 202,
-        blob_count: 1,
-        timestamp: '2026-01-01T00:00:12.000Z',
-        blobs: [liveBlob],
-      },
-    });
+  it('adds a target marker to legacy live blocks by reusing fetched capacity params', () => {
     vi.mocked(useApiData<LatestBlocksResponse>).mockReturnValue({
       data: {
         data: [makeBlock({ id: 201, number: '201', blobGasUsed: 0, blobCount: 0 })],
@@ -135,7 +218,21 @@ describe('RecentBlocksPanel', () => {
       refetch: vi.fn(),
     });
 
-    render(<RecentBlocksPanel />);
+    renderRecentBlocksPanel();
+
+    act(() => {
+      MockWebSocket.instances[0].open();
+      MockWebSocket.instances[0].receive(
+        makeLegacyNewBlockMessage(
+          202,
+          makeBlob(202, 0, {
+            tx_hash: '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+            timestamp: '2026-01-01T00:00:12.000Z',
+            blob_gas_used: 655360,
+          })
+        )
+      );
+    });
 
     expect(screen.getByText('5/21 blobs')).toBeInTheDocument();
     const liveMeter = screen.getAllByRole('meter', { name: 'Under target' })[0];
@@ -143,5 +240,26 @@ describe('RecentBlocksPanel', () => {
     expect(liveMeter.querySelector('[title="Target"]')).toHaveStyle({
       left: '66.66666666666666%',
     });
+  });
+
+  it('builds a rolling recent block list from websocket events before REST data arrives', () => {
+    renderRecentBlocksPanel();
+
+    act(() => {
+      MockWebSocket.instances[0].open();
+      MockWebSocket.instances[0].receive(makeNewBlockMessage(201, 1));
+    });
+
+    expect(screen.getByRole('button', { name: 'View blob details for block 201' })).toBeInTheDocument();
+
+    act(() => {
+      MockWebSocket.instances[0].receive(makeNewBlockMessage(202, 2));
+    });
+
+    expect(screen.getByRole('button', { name: 'View blob details for block 202' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'View blob details for block 201' })).toBeInTheDocument();
+    expect(screen.getByText('2/6 blobs')).toBeInTheDocument();
+    expect(screen.getByText('33%')).toBeInTheDocument();
+    expect(screen.queryByText('Error loading data')).not.toBeInTheDocument();
   });
 });

--- a/src/components/RecentBlocksPanel.tsx
+++ b/src/components/RecentBlocksPanel.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useApiData } from '../hooks/useApiData';
 import { api } from '../lib/api';
 import { useNetwork } from '../hooks/useNetwork';
-import { useLatestBlobEvent } from '../contexts/LiveDataContext';
+import { useLiveBlobEvent } from '../contexts/LiveDataContext';
 import { transformNewBlockData } from '../lib/api/blocks';
 import DataStateWrapper from './DataStateWrapper';
 import { BlobDetailsContent } from './BlobDetailsContent';
@@ -149,6 +149,73 @@ function addCapacityFallback(block: Block, fallbackBlock: Block | undefined): Bl
   };
 }
 
+function mergeBlocks(blocks: Block[], nextBlock: Block): Block[] {
+  return [
+    nextBlock,
+    ...blocks.filter((block) => block.number !== nextBlock.number),
+  ].slice(0, HOMEPAGE_BLOCK_ROWS);
+}
+
+function mergeLiveAndFetchedBlocks(liveBlocks: Block[], fetchedBlocks: Block[]): Block[] {
+  const mergedBlocks = new Map<string, Block>();
+  const fallbackBlock = fetchedBlocks[0];
+
+  for (const block of fetchedBlocks) {
+    mergedBlocks.set(block.number, block);
+  }
+
+  for (const block of liveBlocks) {
+    const fetchedBlock = mergedBlocks.get(block.number);
+    const liveBlock = addCapacityFallback(block, fetchedBlock ?? fallbackBlock);
+    mergedBlocks.set(
+      liveBlock.number,
+      fetchedBlock ? mergeBlockDetails(liveBlock, fetchedBlock) : liveBlock
+    );
+  }
+
+  return Array.from(mergedBlocks.values())
+    .sort((left, right) => Number(right.number) - Number(left.number))
+    .slice(0, HOMEPAGE_BLOCK_ROWS);
+}
+
+function mergeBlockDetails(liveBlock: Block, fetchedBlock: Block): Block {
+  const maxBlobs = liveBlock.maxBlobs || fetchedBlock.maxBlobs;
+  const targetBlobs = liveBlock.targetBlobs || fetchedBlock.targetBlobs;
+  const utilizationPercent = liveBlock.utilizationPercent || (
+    maxBlobs > 0 ? (liveBlock.blobCount / maxBlobs) * 100 : fetchedBlock.utilizationPercent
+  );
+
+  return {
+    ...fetchedBlock,
+    ...liveBlock,
+    blockUrl: liveBlock.blockUrl || fetchedBlock.blockUrl,
+    blobGasUsed: liveBlock.blobGasUsed || fetchedBlock.blobGasUsed,
+    blobGasTarget: liveBlock.blobGasTarget || fetchedBlock.blobGasTarget,
+    blobGasLimit: liveBlock.blobGasLimit || fetchedBlock.blobGasLimit,
+    targetBlobs,
+    maxBlobs,
+    availableBlobs: liveBlock.maxBlobs > 0
+      ? liveBlock.availableBlobs
+      : maxBlobs > 0
+        ? Math.max(0, maxBlobs - liveBlock.blobCount)
+        : fetchedBlock.availableBlobs,
+    baseFeeGwei: liveBlock.baseFeeGwei !== '0' ? liveBlock.baseFeeGwei : fetchedBlock.baseFeeGwei,
+    utilizationPercent,
+    isFull: maxBlobs > 0 ? liveBlock.blobCount >= maxBlobs : liveBlock.isFull || fetchedBlock.isFull,
+    isAboveTarget: targetBlobs > 0
+      ? liveBlock.blobCount > targetBlobs
+      : liveBlock.isAboveTarget || fetchedBlock.isAboveTarget,
+    attribution: hasKnownAttribution(liveBlock.attribution)
+      ? liveBlock.attribution
+      : fetchedBlock.attribution,
+    blobs: liveBlock.blobs.length > 0 ? liveBlock.blobs : fetchedBlock.blobs,
+  };
+}
+
+function hasKnownAttribution(attribution: string[]): boolean {
+  return attribution.some((name) => name !== 'Unknown');
+}
+
 function BlockRow({
   block,
   isExpanded,
@@ -234,37 +301,51 @@ function BlockRow({
 
 export default function RecentBlocksPanel() {
   const { selectedNetwork } = useNetwork();
-  const liveBlockEvent = useLatestBlobEvent('new_block');
-  const [expandedBlockId, setExpandedBlockId] = React.useState<number | null>(null);
-  const [networkKey, setNetworkKey] = React.useState(selectedNetwork.apiParam);
+  const network = selectedNetwork.apiParam;
+  const [liveBlockState, setLiveBlockState] = React.useState<{
+    network: string;
+    blocks: Block[];
+  }>({ network, blocks: [] });
+  const [expandedBlockState, setExpandedBlockState] = React.useState<{
+    network: string;
+    blockId: number | null;
+  }>({ network, blockId: null });
+  const expandedBlockId = expandedBlockState.network === network
+    ? expandedBlockState.blockId
+    : null;
 
-  if (networkKey !== selectedNetwork.apiParam) {
-    setNetworkKey(selectedNetwork.apiParam);
-    setExpandedBlockId(null);
-  }
+  useLiveBlobEvent('new_block', (event) => {
+    const liveBlock = transformNewBlockData(event.data);
+    setLiveBlockState((currentState) => ({
+      network,
+      blocks: mergeBlocks(
+        currentState.network === network ? currentState.blocks : [],
+        liveBlock
+      ),
+    }));
+  });
 
   const { data, isLoading, error } = useApiData<LatestBlocksResponse>(
-    () => api.getLatestBlocks(HOMEPAGE_BLOCK_ROWS, selectedNetwork.apiParam),
-    ['latest-blocks-home', selectedNetwork.apiParam, HOMEPAGE_BLOCK_ROWS]
+    () => api.getLatestBlocks(HOMEPAGE_BLOCK_ROWS, network),
+    ['latest-blocks-home', network, HOMEPAGE_BLOCK_ROWS]
   );
 
   const displayBlocks = React.useMemo<Block[]>(() => {
     const baseBlocks = data?.data ?? [];
-    if (!liveBlockEvent) return baseBlocks.slice(0, HOMEPAGE_BLOCK_ROWS);
-
-    const liveBlock = addCapacityFallback(
-      transformNewBlockData(liveBlockEvent.data),
-      baseBlocks[0]
-    );
-    return [
-      liveBlock,
-      ...baseBlocks.filter((block) => block.number !== liveBlock.number),
-    ].slice(0, HOMEPAGE_BLOCK_ROWS);
-  }, [data, liveBlockEvent]);
+    const currentLiveBlocks = liveBlockState.network === network ? liveBlockState.blocks : [];
+    return mergeLiveAndFetchedBlocks(currentLiveBlocks, baseBlocks);
+  }, [data, liveBlockState, network]);
 
   const toggleBlock = React.useCallback((blockId: number) => {
-    setExpandedBlockId((current) => (current === blockId ? null : blockId));
-  }, []);
+    setExpandedBlockState((currentState) => {
+      const currentBlockId = currentState.network === network ? currentState.blockId : null;
+
+      return {
+        network,
+        blockId: currentBlockId === blockId ? null : blockId,
+      };
+    });
+  }, [network]);
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>, blockId: number) => {

--- a/src/lib/api/blocks.test.ts
+++ b/src/lib/api/blocks.test.ts
@@ -185,4 +185,45 @@ describe('api/blocks', () => {
       baseFeeGwei: '1',
     });
   });
+
+  it('uses websocket block pricing when present on live block data', () => {
+    const block = transformNewBlockData({
+      block_number: 103,
+      blob_count: 2,
+      timestamp: '2026-01-01T00:00:30.000Z',
+      blobs: [],
+      pricing: {
+        block_number: 103,
+        block_timestamp: '2026-01-01T00:00:30.000Z',
+        blob_count: 2,
+        blob_gas_used: 262144,
+        blob_gas_target: 393216,
+        blob_gas_limit: 786432,
+        excess_blob_gas: 0,
+        blob_base_fee: '250000000',
+        blob_base_fee_gwei: '0.25',
+        utilization_ratio: '0.3333',
+        blob_params_target: 3,
+        blob_params_max: 6,
+        target_blobs: 3,
+        max_blobs: 6,
+        available_blobs: 4,
+        utilization_percent: 33.33,
+        is_full: false,
+        is_above_target: false,
+        update_fraction: 3338477,
+      },
+    });
+
+    expect(block).toMatchObject({
+      blobCount: 2,
+      blobGasUsed: 262144,
+      blobGasTarget: 393216,
+      maxBlobs: 6,
+      targetBlobs: 3,
+      availableBlobs: 4,
+      utilizationPercent: 33.33,
+      baseFeeGwei: '0.25',
+    });
+  });
 });

--- a/src/lib/api/blocks.ts
+++ b/src/lib/api/blocks.ts
@@ -36,25 +36,26 @@ export function transformNewBlockData(
     blockData: NewBlockData,
     pricingBlock?: BackendBlobPricingRecentBlock
 ): Block {
-    const maxBlobs = pricingBlock?.max_blobs ?? 0;
-    const targetBlobs = pricingBlock?.target_blobs || 0;
-    const utilizationPercent = pricingBlock?.utilization_percent ?? 0;
+    const blockPricing = pricingBlock ?? blockData.pricing;
+    const maxBlobs = blockPricing?.max_blobs ?? 0;
+    const targetBlobs = blockPricing?.target_blobs || 0;
+    const utilizationPercent = blockPricing?.utilization_percent ?? 0;
 
     return {
         id: blockData.block_number,
         number: blockData.block_number.toString(),
         blockUrl: getBlockUrl(blockData.blobs),
-        blobCount: pricingBlock?.blob_count ?? blockData.blob_count,
-        blobGasUsed: pricingBlock?.blob_gas_used ?? getBlobGasUsed(blockData.blobs),
-        blobGasTarget: pricingBlock?.blob_gas_target ?? 0,
-        blobGasLimit: pricingBlock?.blob_gas_limit ?? 0,
+        blobCount: blockPricing?.blob_count ?? blockData.blob_count,
+        blobGasUsed: blockPricing?.blob_gas_used ?? getBlobGasUsed(blockData.blobs),
+        blobGasTarget: blockPricing?.blob_gas_target ?? 0,
+        blobGasLimit: blockPricing?.blob_gas_limit ?? 0,
         targetBlobs,
         maxBlobs,
-        availableBlobs: pricingBlock?.available_blobs ?? 0,
-        baseFeeGwei: pricingBlock?.blob_base_fee_gwei ?? getBlockBaseFeeGwei(blockData.blobs),
+        availableBlobs: blockPricing?.available_blobs ?? 0,
+        baseFeeGwei: blockPricing?.blob_base_fee_gwei ?? getBlockBaseFeeGwei(blockData.blobs),
         utilizationPercent,
-        isFull: pricingBlock?.is_full ?? false,
-        isAboveTarget: pricingBlock?.is_above_target ?? false,
+        isFull: blockPricing?.is_full ?? false,
+        isAboveTarget: blockPricing?.is_above_target ?? false,
         timestamp: blockData.timestamp,
         attribution: getAttributions(blockData.blobs),
         blobs: blockData.blobs

--- a/src/lib/api/mempool.ts
+++ b/src/lib/api/mempool.ts
@@ -20,7 +20,7 @@ import {
 export function transformBlobToMempoolTransaction(blob: BlobResponse, index: number): MempoolTransaction {
     const realizedCost = blob.realized_cost_wei
         ? formatBlobWeiCost(blob.realized_cost_wei)
-        : formatBlobTotalCost(blob.total_cost_eth);
+        : formatBlobTotalCost(blob.total_cost_wei || blob.total_cost_eth);
 
     return {
         id: index + 1,

--- a/src/lib/api/stats.test.ts
+++ b/src/lib/api/stats.test.ts
@@ -60,6 +60,26 @@ describe('api/stats', () => {
     expect(result.data.averageTotalCost).toBe('0.002203603226459001927 ETH');
   });
 
+  it('prefers primary websocket stats fields over deprecated aliases', () => {
+    const result = transformStatsResponse({
+      total_blobs: 100,
+      total_confirmed_blobs: 80,
+      total_pending_blobs: 20,
+      average_base_fee_per_blob_gas_wei: '3000000000',
+      average_tip_per_blob_gas_wei: '4000000000',
+      average_total_cost_wei: '900000000000000',
+      average_base_fee: '1000000000',
+      average_tip: '2000000000',
+      average_total_cost: '500000000000000',
+      last_indexed_block: 12345,
+      last_indexed_time: '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(result.data.averageBaseFee).toBe('3 Gwei');
+    expect(result.data.averageTip).toBe('4 Gwei');
+    expect(result.data.averageTotalCost).toBe('0.0009 ETH');
+  });
+
   it('fetches rolling stats windows with typed response data', async () => {
     const mockWindows = [
       {

--- a/src/lib/api/stats.ts
+++ b/src/lib/api/stats.ts
@@ -12,15 +12,19 @@ import { formatWeiToEth, formatWeiToReadable } from '../../utils';
 export const DEFAULT_STATS_WINDOWS: RollingWindowKey[] = ['5m', '1h', '24h', '7d', '30d'];
 
 export function transformStatsResponse(stats: BackendStatsResponse | WebSocketStatsResponse): StatsResponse {
+    const averageBaseFeeWei = stats.average_base_fee_per_blob_gas_wei || stats.average_base_fee || '0';
+    const averageTipWei = stats.average_tip_per_blob_gas_wei || stats.average_tip || '0';
+    const averageTotalCostWei = stats.average_total_cost_wei || stats.average_total_cost || '0';
+
     return {
         data: {
-            averageBaseFee: formatWeiToReadable(stats.average_base_fee || '0'),
+            averageBaseFee: formatWeiToReadable(averageBaseFeeWei),
             totalBlobs: stats.total_blobs,
             totalConfirmedBlobs: stats.total_confirmed_blobs,
             pendingBlobsCount: stats.total_pending_blobs,
             avgBlobsPerBlock: Math.round(((stats.total_confirmed_blobs || 100) / 100) * 10) / 10,
-            averageTip: formatWeiToReadable(stats.average_tip || '0'),
-            averageTotalCost: formatWeiToEth(stats.average_total_cost || '0'),
+            averageTip: formatWeiToReadable(averageTipWei),
+            averageTotalCost: formatWeiToEth(averageTotalCostWei),
             lastIndexedBlock: stats.last_indexed_block,
             lastIndexedTime: stats.last_indexed_time
         }

--- a/src/lib/api/users.test.ts
+++ b/src/lib/api/users.test.ts
@@ -20,7 +20,8 @@ describe('api/users', () => {
             address: '0x1234567890abcdef',
             name: '',
             blob_count: 3,
-            total_cost_eth: '1.2',
+            total_cost_wei: '1200000000000000000',
+            total_cost_eth: '99',
             last_timestamp: '2026-01-01T00:00:00.000Z',
           },
           {
@@ -47,6 +48,8 @@ describe('api/users', () => {
       name: '0x1234...cdef',
       dataCount: 3,
       percentage: 75,
+      totalCostEth: '1.2',
+      totalCostWei: '1200000000000000000',
     });
     expect(result.data[1].name).toBe('Known User');
   });

--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -2,6 +2,8 @@ import { TopUsersResponse, User, ApiResponse, UserResponse, BlobResponse } from 
 import { fetchApi } from './core';
 import { truncateAddress } from '../../utils';
 
+const WEI_PER_ETH = BigInt('1000000000000000000');
+
 export function transformUserResponses(usersResponse: UserResponse[]): TopUsersResponse {
     // Calculate total blobs across all returned users for percentage calculation
     const totalBlobs = usersResponse.reduce((sum, user) => sum + user.blob_count, 0) || 1;
@@ -16,7 +18,8 @@ export function transformUserResponses(usersResponse: UserResponse[]): TopUsersR
             address: user.address,
             dataCount: user.blob_count,
             percentage,
-            totalCostEth: user.total_cost_eth,
+            totalCostEth: formatTotalCostEth(user.total_cost_wei, user.total_cost_eth),
+            totalCostWei: user.total_cost_wei,
             lastTimestamp: user.last_timestamp
         };
     });
@@ -57,3 +60,16 @@ export const getUserBlobs = async (address: string, confirmed: boolean, limit = 
     const response = await fetchApi<ApiResponse<BlobResponse[]>>(`${endpoint}?from=${address}&limit=${limit}`, network);
     return response.data;
 };
+
+function formatTotalCostEth(totalCostWei: string | undefined, fallbackTotalCostEth: string): string {
+    if (!totalCostWei || !/^\d+$/.test(totalCostWei)) {
+        return fallbackTotalCostEth;
+    }
+
+    const wei = BigInt(totalCostWei);
+    const wholeEth = wei / WEI_PER_ETH;
+    const fractionalWei = wei % WEI_PER_ETH;
+    const fractionalEth = fractionalWei.toString().padStart(18, '0').replace(/0+$/, '');
+
+    return fractionalEth ? `${wholeEth}.${fractionalEth}` : wholeEth.toString();
+}

--- a/src/lib/blobWebSocket.test.ts
+++ b/src/lib/blobWebSocket.test.ts
@@ -109,6 +109,27 @@ describe('blobWebSocket', () => {
           blob_count: 1,
           timestamp: '2026-03-09T14:00:00Z',
           blobs: [blobResponse],
+          pricing: {
+            block_number: 123,
+            block_timestamp: '2026-03-09T14:00:00Z',
+            blob_count: 1,
+            blob_gas_used: 131072,
+            blob_gas_target: 393216,
+            blob_gas_limit: 786432,
+            excess_blob_gas: 0,
+            blob_base_fee: '1000000000',
+            blob_base_fee_gwei: '1',
+            utilization_ratio: '0.1667',
+            blob_params_target: 3,
+            blob_params_max: 6,
+            target_blobs: 3,
+            max_blobs: 6,
+            available_blobs: 5,
+            utilization_percent: 16.67,
+            is_full: false,
+            is_above_target: false,
+            update_fraction: 3338477,
+          },
         },
       })
     );
@@ -117,6 +138,7 @@ describe('blobWebSocket', () => {
     if (parsed?.type === 'new_block') {
       expect(parsed.data.blob_count).toBe(1);
       expect(parsed.data.blobs[0].tx_hash).toBe('0xabc123');
+      expect(parsed.data.pricing?.max_blobs).toBe(6);
     }
   });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,7 @@ export interface BlobResponse {
   base_fee_per_blob_gas_gwei?: string;
   tip_per_blob_gas: string;
   tip_per_blob_gas_gwei?: string;
+  total_cost_wei?: string;
   total_cost_eth: string;
   timestamp: string;
   confirmed: boolean;
@@ -65,6 +66,7 @@ export interface NewBlockData {
   blob_count: number;
   timestamp: string;
   blobs: BlobResponse[];
+  pricing?: BackendBlobPricingRecentBlock;
 }
 
 export interface NewBlockEvent {
@@ -387,6 +389,7 @@ export interface UserResponse {
   name?: string;
   category?: string;
   blob_count: number;
+  total_cost_wei?: string;
   total_cost_eth: string;
   last_timestamp: string;
   blob_share_percent?: number;
@@ -401,6 +404,7 @@ export interface User {
   dataCount: number;
   percentage: number;
   totalCostEth: string;
+  totalCostWei?: string;
   lastTimestamp: string;
 }
 
@@ -416,6 +420,9 @@ export interface BackendStatsResponse {
   total_blobs: number;
   total_confirmed_blobs: number;
   total_pending_blobs: number;
+  average_base_fee_per_blob_gas_wei?: string;
+  average_tip_per_blob_gas_wei?: string;
+  average_total_cost_wei?: string;
   average_base_fee: string;
   average_tip: string;
   average_total_cost: string;


### PR DESCRIPTION
## Summary

- keep a rolling list of `new_block` websocket events for the Recent Block Fees panel
- read `new_block.data.pricing` from the updated websocket AsyncAPI contract so live rows include capacity, utilization, and base-fee fields
- prefer new websocket primary fields such as `total_cost_wei` and `average_*_wei` while retaining legacy alias fallbacks
- add coverage for websocket pricing and live population before REST data arrives

## Root cause

Recent Block Fees only read the latest websocket event, so each live block replaced the previous one instead of building the recent block list. The original websocket payload also lacked the REST pricing fields needed for complete live rows.

## Validation

- `npm test -- RecentBlocksPanel.test.tsx blocks.test.ts blobWebSocket.test.ts stats.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- browser smoke test on `http://localhost:3001` showed the panel advancing live while staying populated with five rows