### PR TITLE
fix: align recent block usage indicators

### DIFF
--- a/src/components/RecentBlocksPanel.test.tsx
+++ b/src/components/RecentBlocksPanel.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DEFAULT_NETWORK } from '../constants';
+import { useLatestBlobEvent } from '../contexts/LiveDataContext';
+import { useApiData } from '../hooks/useApiData';
+import { useNetwork } from '../hooks/useNetwork';
+import { BlobResponse, Block, LatestBlocksResponse } from '../types';
+import RecentBlocksPanel from './RecentBlocksPanel';
+
+vi.mock('../hooks/useApiData', () => ({
+  useApiData: vi.fn(),
+}));
+
+vi.mock('../hooks/useNetwork', () => ({
+  useNetwork: vi.fn(),
+}));
+
+vi.mock('../contexts/LiveDataContext', () => ({
+  useLatestBlobEvent: vi.fn(),
+}));
+
+function makeBlock(overrides: Partial<Block>): Block {
+  return {
+    id: 200,
+    number: '200',
+    blobCount: 1,
+    blobGasUsed: 655360,
+    blobGasTarget: 1835008,
+    blobGasLimit: 2752512,
+    targetBlobs: 14,
+    maxBlobs: 21,
+    availableBlobs: 20,
+    baseFeeGwei: '1',
+    utilizationPercent: 4.76,
+    isFull: false,
+    isAboveTarget: true,
+    timestamp: '2026-01-01T00:00:00.000Z',
+    attribution: ['Base'],
+    blobs: [],
+    ...overrides,
+  };
+}
+
+const liveBlob: BlobResponse = {
+  network_id: 1,
+  network_name: 'mainnet',
+  block_number: 202,
+  blob_index: 0,
+  tx_hash: '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+  from_address: '0x1234567890abcdef1234567890abcdef12345678',
+  blob_size_bytes: 131072,
+  base_fee_per_blob_gas: '1000000000',
+  base_fee_per_blob_gas_gwei: '1',
+  tip_per_blob_gas: '0',
+  total_cost_eth: '0.001',
+  timestamp: '2026-01-01T00:00:12.000Z',
+  confirmed: true,
+  user_attribution: 'Base',
+  blob_gas_used: 655360,
+};
+
+describe('RecentBlocksPanel', () => {
+  beforeEach(() => {
+    vi.mocked(useNetwork).mockReturnValue({
+      selectedNetwork: DEFAULT_NETWORK,
+      setSelectedNetwork: vi.fn(),
+      networkOptions: [DEFAULT_NETWORK],
+    });
+    vi.mocked(useLatestBlobEvent).mockReturnValue(null);
+  });
+
+  it('derives blob usage and target state from blob gas for matching labels and colors', () => {
+    vi.mocked(useApiData<LatestBlocksResponse>).mockReturnValue({
+      data: {
+        data: [
+          makeBlock({ id: 200, number: '200' }),
+          makeBlock({
+            id: 201,
+            number: '201',
+            blobCount: 2,
+            blobGasUsed: 2097152,
+            availableBlobs: 19,
+            utilizationPercent: 9.52,
+            isAboveTarget: false,
+          }),
+        ],
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<RecentBlocksPanel />);
+
+    expect(screen.getByText('5/21 blobs')).toBeInTheDocument();
+    expect(screen.getByText('24%')).toBeInTheDocument();
+    expect(screen.getByText('16/21 blobs')).toBeInTheDocument();
+    expect(screen.getByText('76%')).toBeInTheDocument();
+
+    const underTargetText = screen.getByText('Under target');
+    expect(underTargetText).toHaveClass('text-green-400');
+    const underTargetMeter = screen.getByRole('meter', { name: 'Under target' });
+    expect(underTargetMeter).toHaveAttribute('aria-valuetext', 'Under target; target at 67%');
+    expect(underTargetMeter.firstElementChild).toHaveClass('bg-green-400');
+    expect(underTargetMeter.querySelector('[title="Target"]')).toHaveStyle({
+      left: '66.66666666666666%',
+    });
+
+    const aboveTargetText = screen.getByText('Above target');
+    expect(aboveTargetText).toHaveClass('text-amber-300');
+    const aboveTargetMeter = screen.getByRole('meter', { name: 'Above target' });
+    expect(aboveTargetMeter).toHaveAttribute('aria-valuetext', 'Above target; target at 67%');
+    expect(aboveTargetMeter.firstElementChild).toHaveClass('bg-amber-300');
+    expect(aboveTargetMeter.querySelector('[title="Target"]')).toHaveStyle({
+      left: '66.66666666666666%',
+    });
+  });
+
+  it('adds a target marker to live blocks by reusing fetched capacity params', () => {
+    vi.mocked(useLatestBlobEvent).mockReturnValue({
+      type: 'new_block',
+      data: {
+        block_number: 202,
+        blob_count: 1,
+        timestamp: '2026-01-01T00:00:12.000Z',
+        blobs: [liveBlob],
+      },
+    });
+    vi.mocked(useApiData<LatestBlocksResponse>).mockReturnValue({
+      data: {
+        data: [makeBlock({ id: 201, number: '201', blobGasUsed: 0, blobCount: 0 })],
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<RecentBlocksPanel />);
+
+    expect(screen.getByText('5/21 blobs')).toBeInTheDocument();
+    const liveMeter = screen.getAllByRole('meter', { name: 'Under target' })[0];
+    expect(liveMeter).toHaveAttribute('aria-valuetext', 'Under target; target at 67%');
+    expect(liveMeter.querySelector('[title="Target"]')).toHaveStyle({
+      left: '66.66666666666666%',
+    });
+  });
+});

--- a/src/components/RecentBlocksPanel.tsx
+++ b/src/components/RecentBlocksPanel.tsx
@@ -13,16 +13,119 @@ import { Block, LatestBlocksResponse } from '../types';
 import { formatBlobFee, formatPercent } from '../utils';
 import { HOMEPAGE_BLOCK_ROWS } from '../constants';
 
-function FullnessBar({ percent, isAboveTarget }: { percent: number; isAboveTarget: boolean }) {
+interface UsageState {
+  label: 'Above target' | 'Under target';
+  fillClass: string;
+  textClass: string;
+}
+
+interface BlockUsage {
+  usedBlobs: number;
+  maxBlobs: number;
+  targetPercent: number | null;
+  utilizationPercent: number;
+  state: UsageState;
+}
+
+const ABOVE_TARGET_STATE: UsageState = {
+  label: 'Above target',
+  fillClass: 'bg-amber-300',
+  textClass: 'text-amber-300',
+};
+
+const UNDER_TARGET_STATE: UsageState = {
+  label: 'Under target',
+  fillClass: 'bg-green-400',
+  textClass: 'text-green-400',
+};
+
+function getGasPerBlob(block: Block): number {
+  if (block.blobGasTarget > 0 && block.targetBlobs > 0) {
+    return block.blobGasTarget / block.targetBlobs;
+  }
+
+  if (block.blobGasLimit > 0 && block.maxBlobs > 0) {
+    return block.blobGasLimit / block.maxBlobs;
+  }
+
+  return 0;
+}
+
+function getUsedBlobCount(block: Block): number {
+  const gasPerBlob = getGasPerBlob(block);
+  if (block.blobGasUsed > 0 && gasPerBlob > 0) {
+    return Math.ceil(block.blobGasUsed / gasPerBlob);
+  }
+
+  return block.blobCount;
+}
+
+function getBlockUsage(block: Block): BlockUsage {
+  const usedBlobs = getUsedBlobCount(block);
+  const maxBlobs = block.maxBlobs;
+  const utilizationPercent = block.blobGasLimit > 0
+    ? (block.blobGasUsed / block.blobGasLimit) * 100
+    : block.utilizationPercent;
+  const targetPercent = block.blobGasLimit > 0 && block.blobGasTarget > 0
+    ? (block.blobGasTarget / block.blobGasLimit) * 100
+    : block.maxBlobs > 0 && block.targetBlobs > 0
+      ? (block.targetBlobs / block.maxBlobs) * 100
+      : null;
+  const isAboveTarget = block.blobGasTarget > 0
+    ? block.blobGasUsed > block.blobGasTarget
+    : block.targetBlobs > 0
+      ? usedBlobs > block.targetBlobs
+      : block.isAboveTarget;
+
+  return {
+    usedBlobs,
+    maxBlobs,
+    targetPercent,
+    utilizationPercent,
+    state: isAboveTarget ? ABOVE_TARGET_STATE : UNDER_TARGET_STATE,
+  };
+}
+
+function FullnessBar({
+  percent,
+  targetPercent,
+  state,
+}: {
+  percent: number;
+  targetPercent: number | null;
+  state: UsageState;
+}) {
   const boundedPercent = Math.min(100, Math.max(0, percent));
-  const fillClass = isAboveTarget ? 'bg-amber-300' : 'bg-green-400';
+  const boundedTargetPercent = targetPercent === null
+    ? null
+    : Math.min(100, Math.max(0, targetPercent));
 
   return (
-    <div className="h-2 overflow-hidden rounded-full bg-[#202538]">
+    <div
+      className="relative h-2 overflow-hidden rounded-full bg-[#202538]"
+      role="meter"
+      aria-label={state.label}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round(boundedPercent)}
+      aria-valuetext={
+        boundedTargetPercent === null
+          ? state.label
+          : `${state.label}; target at ${Math.round(boundedTargetPercent)}%`
+      }
+    >
       <div
-        className={`h-full rounded-full ${fillClass}`}
+        className={`h-full rounded-full ${state.fillClass}`}
         style={{ width: `${boundedPercent}%` }}
       />
+      {boundedTargetPercent !== null && (
+        <span
+          aria-hidden="true"
+          className="absolute inset-y-0 w-0.5 -translate-x-1/2 rounded-full bg-white/90 shadow-[0_0_0_1px_rgba(15,19,34,0.85)]"
+          style={{ left: `${boundedTargetPercent}%` }}
+          title="Target"
+        />
+      )}
     </div>
   );
 }
@@ -32,10 +135,18 @@ function formatBaseFee(block: Block): string {
   return formatBlobFee(block.baseFeeGwei);
 }
 
-function getBlockState(block: Block): string {
-  if (block.isFull) return 'Full';
-  if (block.isAboveTarget) return 'Above target';
-  return 'Under target';
+function addCapacityFallback(block: Block, fallbackBlock: Block | undefined): Block {
+  if (block.maxBlobs > 0 || !fallbackBlock || fallbackBlock.maxBlobs <= 0) {
+    return block;
+  }
+
+  return {
+    ...block,
+    blobGasTarget: fallbackBlock.blobGasTarget,
+    blobGasLimit: fallbackBlock.blobGasLimit,
+    targetBlobs: fallbackBlock.targetBlobs,
+    maxBlobs: fallbackBlock.maxBlobs,
+  };
 }
 
 function BlockRow({
@@ -50,8 +161,9 @@ function BlockRow({
   onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
 }) {
   const detailsId = `recent-block-${block.id}-details`;
-  const fillLabel = block.maxBlobs > 0 ? `${block.blobCount}/${block.maxBlobs}` : `${block.blobCount}`;
-  const utilization = block.maxBlobs > 0 ? formatPercent(block.utilizationPercent, 0) : '-';
+  const usage = getBlockUsage(block);
+  const fillLabel = usage.maxBlobs > 0 ? `${usage.usedBlobs}/${usage.maxBlobs}` : `${usage.usedBlobs}`;
+  const utilization = usage.maxBlobs > 0 ? formatPercent(usage.utilizationPercent, 0) : '-';
 
   return (
     <div
@@ -94,7 +206,11 @@ function BlockRow({
             <span>{fillLabel} blobs</span>
             <span>{utilization}</span>
           </div>
-          <FullnessBar percent={block.utilizationPercent} isAboveTarget={block.isAboveTarget} />
+          <FullnessBar
+            percent={usage.utilizationPercent}
+            targetPercent={usage.targetPercent}
+            state={usage.state}
+          />
         </div>
         <div className="min-w-0">
           <div className="text-[11px] text-[#8f9aad]">Base fee</div>
@@ -102,7 +218,9 @@ function BlockRow({
         </div>
         <div className="min-w-0">
           <div className="text-[11px] text-[#8f9aad]">State</div>
-          <div className="truncate text-sm font-medium text-white">{getBlockState(block)}</div>
+          <div className={`truncate text-sm font-medium ${usage.state.textClass}`}>
+            {usage.state.label}
+          </div>
         </div>
       </div>
       {isExpanded && (
@@ -135,7 +253,10 @@ export default function RecentBlocksPanel() {
     const baseBlocks = data?.data ?? [];
     if (!liveBlockEvent) return baseBlocks.slice(0, HOMEPAGE_BLOCK_ROWS);
 
-    const liveBlock = transformNewBlockData(liveBlockEvent.data);
+    const liveBlock = addCapacityFallback(
+      transformNewBlockData(liveBlockEvent.data),
+      baseBlocks[0]
+    );
     return [
       liveBlock,
       ...baseBlocks.filter((block) => block.number !== liveBlock.number),


### PR DESCRIPTION
## Summary
- derive Recent Block Fees usage from blob gas and capacity data instead of the raw blob record count
- use one derived target state for the usage bar fill and State text color
- add a visible target marker on each capacity-aware usage bar, including live rows that temporarily borrow the latest fetched capacity params

## Root Cause
The panel could display raw `blob_count` while the backend pricing data reported higher `blob_gas_used`, so rows under target could look misleading or use state/color signals that did not feel connected to the actual blob usage.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`
- browser smoke check on the local app