### PR TITLE
fix: stabilize top users table data

### DIFF
--- a/src/components/TopUsersTable.tsx
+++ b/src/components/TopUsersTable.tsx
@@ -43,6 +43,7 @@ const COLUMN_WIDTHS: Record<string, string> = {
   dataCount: 'w-1/3',
   percentage: 'w-1/3',
 };
+const EMPTY_USERS: User[] = [];
 
 function getUserColor(userName: string): string {
   switch (userName.toLowerCase()) {
@@ -129,9 +130,11 @@ export default function TopUsersTable() {
     () => api.getTopUsers(10, selectedNetwork.apiParam),
     ['top-users', selectedNetwork.apiParam, 10]
   );
-  const displayData = usersUpdateEvent
-    ? transformUserResponses(usersUpdateEvent.data)
-    : data;
+  const displayData = React.useMemo(
+    () => (usersUpdateEvent ? transformUserResponses(usersUpdateEvent.data) : data),
+    [data, usersUpdateEvent]
+  );
+  const tableData = displayData?.data ?? EMPTY_USERS;
   const tbodyRef = React.useRef<HTMLTableSectionElement | null>(null);
   useFlipRows(tbodyRef, selectedNetwork.apiParam);
 
@@ -191,7 +194,7 @@ export default function TopUsersTable() {
   );
 
   const table = useReactTable({
-    data: displayData?.data ?? [],
+    data: tableData,
     columns,
     state: {
       sorting,


### PR DESCRIPTION
## Summary

- Memoize live `users_update` transformations before passing data into TanStack Table.
- Use a stable empty users array so the table does not receive a new `[]` on each render.

## Root Cause

After PR #62, `TopUsersTable` transformed WebSocket user updates directly during render. Once a `users_update` event arrived, that produced a fresh data array on every render. TanStack Table treated the input as changed and scheduled more work, causing a near-continuous render loop that drove CPU and memory pressure until tabs became unresponsive or crashed.

## Validation

- `npm run lint` passed with the existing TanStack/React Compiler warning only.
- `npm run typecheck` passed.
- `NEXT_PUBLIC_USE_MOCK_DATA=false NEXT_PUBLIC_API_URL=https://blob-indexer.ahkc.win/api/v1 npm run build` passed.
- `npm test` passed: 85 tests.
- Chrome CDP soak after a clean reload showed about `0.19s` script time over 60 seconds, stable DOM node counts, and no heap growth.