### PR TITLE
fix: replace font awesome icons

### DIFF
--- a/src/app/block/[number]/page.tsx
+++ b/src/app/block/[number]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
+import { ArrowLeft, ExternalLink } from 'lucide-react';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import DataStateWrapper from '@/components/DataStateWrapper';
@@ -81,7 +82,7 @@ export default function BlockDetailPage() {
           href="/blocks"
           className="text-blue hover:underline text-sm mb-6 inline-flex items-center gap-2"
         >
-          <i className="fa-regular fa-arrow-left" aria-hidden="true" />
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           Back to Blocks
         </Link>
 
@@ -110,7 +111,7 @@ export default function BlockDetailPage() {
                   className="text-blue hover:underline text-sm inline-flex items-center gap-2"
                 >
                   View on Etherscan
-                  <i className="fa-regular fa-arrow-up-right-from-square text-xs" aria-hidden="true" />
+                  <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
                 </a>
               </div>
             ) : block ? (
@@ -128,10 +129,7 @@ export default function BlockDetailPage() {
                         className="text-blue hover:underline text-sm inline-flex items-center gap-2"
                       >
                         View on Etherscan
-                        <i
-                          className="fa-regular fa-arrow-up-right-from-square text-xs"
-                          aria-hidden="true"
-                        />
+                        <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
                       </a>
                     )}
                   </div>

--- a/src/app/blocks/page.tsx
+++ b/src/app/blocks/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import LatestBlocksTable from '@/components/LatestBlocksTable';
@@ -14,7 +15,7 @@ export default function BlocksPage() {
           href="/"
           className="text-blue hover:underline text-sm mb-6 inline-flex items-center gap-2"
         >
-          <i className="fa-regular fa-arrow-left" aria-hidden="true" />
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           Back to Dashboard
         </Link>
 

--- a/src/app/charts/[chart]/page.tsx
+++ b/src/app/charts/[chart]/page.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
+import { ArrowLeft, Minimize2 } from 'lucide-react';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import DataStateWrapper from '@/components/DataStateWrapper';
@@ -91,7 +92,7 @@ function ChartDetail({ view }: { view: ChartView }) {
               href="/#data-trends"
               className="inline-flex h-8 items-center justify-center gap-2 self-start rounded-md border border-divider bg-[#1d1f23] px-3 text-sm text-bodyText transition-colors hover:bg-[#252936] hover:text-white focus:outline-none focus:ring-2 focus:ring-blue/60"
             >
-              <i className="fa-regular fa-compress" aria-hidden="true" />
+              <Minimize2 className="h-4 w-4" aria-hidden="true" />
               Dashboard
             </Link>
           </div>
@@ -129,7 +130,7 @@ export default function ChartDetailPage() {
           href="/#data-trends"
           className="text-blue hover:underline text-sm mb-6 inline-flex items-center gap-2"
         >
-          <i className="fa-regular fa-arrow-left" aria-hidden="true" />
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           Back to Dashboard
         </Link>
 

--- a/src/components/LatestBlocksTable.tsx
+++ b/src/components/LatestBlocksTable.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useApiData } from '../hooks/useApiData';
 import { api } from '../lib/api';
 import { Block, BlobResponse, LatestBlocksResponse } from '../types';
@@ -394,9 +394,9 @@ export default function LatestBlocksTable() {
               type="button"
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={safePage <= 1}
-              className="px-3 py-1 rounded-md border border-divider bg-[#1d1f23] text-white disabled:opacity-40 disabled:cursor-not-allowed hover:bg-[#23252a]"
+              className="inline-flex items-center gap-1.5 px-3 py-1 rounded-md border border-divider bg-[#1d1f23] text-white disabled:opacity-40 disabled:cursor-not-allowed hover:bg-[#23252a]"
             >
-              <i className="fa-regular fa-chevron-left text-xs" aria-hidden="true" /> Prev
+              <ChevronLeft className="h-3.5 w-3.5" aria-hidden="true" /> Prev
             </button>
             <span className="px-2">
               Page <span className="text-white">{safePage}</span> of{' '}
@@ -406,9 +406,9 @@ export default function LatestBlocksTable() {
               type="button"
               onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
               disabled={safePage >= totalPages}
-              className="px-3 py-1 rounded-md border border-divider bg-[#1d1f23] text-white disabled:opacity-40 disabled:cursor-not-allowed hover:bg-[#23252a]"
+              className="inline-flex items-center gap-1.5 px-3 py-1 rounded-md border border-divider bg-[#1d1f23] text-white disabled:opacity-40 disabled:cursor-not-allowed hover:bg-[#23252a]"
             >
-              Next <i className="fa-regular fa-chevron-right text-xs" aria-hidden="true" />
+              Next <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
             </button>
           </div>
         </div>

--- a/src/components/MetricsCharts.tsx
+++ b/src/components/MetricsCharts.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Link from 'next/link';
+import { Maximize2 } from 'lucide-react';
 import { useChartData } from '../hooks/useChartData';
 import DataStateWrapper from './DataStateWrapper';
 import FeeIndicators from './charts/FeeIndicators';
@@ -46,7 +47,7 @@ export default function MetricsCharts() {
                     aria-label={`Open ${view.getTitle(chartData)} enlarged`}
                     title="Enlarge graph"
                   >
-                    <i className="fa-regular fa-expand" aria-hidden="true" />
+                    <Maximize2 className="h-4 w-4" aria-hidden="true" />
                   </Link>
                 </div>
                 <div className={view.dashboardFrameClassName}>

--- a/src/components/RecentBlocksPanel.tsx
+++ b/src/components/RecentBlocksPanel.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Link from 'next/link';
+import { ArrowRight, ChevronRight } from 'lucide-react';
 import { useApiData } from '../hooks/useApiData';
 import { api } from '../lib/api';
 import { useNetwork } from '../hooks/useNetwork';
@@ -183,8 +184,8 @@ function BlockRow({
         onKeyDown={onKeyDown}
         className="grid grid-cols-2 sm:grid-cols-[1.25rem_minmax(5.5rem,0.8fr)_minmax(8rem,1.2fr)_minmax(7rem,1fr)_minmax(5.5rem,0.8fr)] items-center gap-3 px-3 py-2 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-blue focus-visible:ring-inset rounded-md"
       >
-        <i
-          className={`hidden sm:inline fa-regular fa-chevron-right text-[10px] text-[#6e7787] transition-transform ${
+        <ChevronRight
+          className={`hidden h-3 w-3 text-[#6e7787] transition-transform sm:inline ${
             isExpanded ? 'rotate-90' : ''
           }`}
           aria-hidden="true"
@@ -306,9 +307,9 @@ export default function RecentBlocksPanel() {
         <h2 className="text-2xl font-windsor-bold text-white">Recent Block Fees</h2>
         <Link
           href="/blocks"
-          className="text-sm text-blue hover:underline whitespace-nowrap"
+          className="inline-flex items-center gap-1 text-sm text-blue hover:underline whitespace-nowrap"
         >
-          View all blocks <i className="fa-regular fa-arrow-right text-xs ml-1" aria-hidden="true" />
+          View all blocks <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
         </Link>
       </div>
 


### PR DESCRIPTION
## Summary

- Replace the dashboard chart enlarge icon with the existing Lucide icon set.
- Replace enlarged chart page back/minimize Font Awesome placeholders with Lucide icons.
- Replace the remaining Font Awesome placeholders across block pages, recent blocks, and block pagination.

## Why

The app does not load Font Awesome, so these `<i className="fa-...">` placeholders rendered blank even though the buttons and links existed in the DOM. Using `lucide-react` matches the icon set already shipped with the app.

## Validation

- `rg` found no remaining Font Awesome usages in `src` or `public`.
- `npm run lint` passes with one existing unrelated TanStack Table React Compiler warning in `src/components/TopUsersTable.tsx`.
- `npm run typecheck` passes.
- Browser verification confirmed the three chart enlarge links each render an SVG icon and the enlarged chart page navigation works.