### PR TITLE
fix: clarify blob capacity display

### DIFF
--- a/src/app/block/[number]/page.tsx
+++ b/src/app/block/[number]/page.tsx
@@ -18,9 +18,9 @@ function formatBaseFee(block: Block): string {
   return formatBlobFee(block.baseFeeGwei);
 }
 
-function formatOpenCapacity(block: Block): string {
+function formatBlobCapacity(block: Block): string {
   if (block.maxBlobs <= 0) return '-';
-  return `${block.availableBlobs}/${block.maxBlobs} open`;
+  return `${block.blobCount}/${block.maxBlobs} used`;
 }
 
 function formatUtilization(block: Block): string {
@@ -151,7 +151,7 @@ export default function BlockDetailPage() {
                     <StatCard label="Blobs" value={block.blobCount.toLocaleString()} />
                     <StatCard label="Utilization" value={formatUtilization(block)} />
                     <StatCard label="Base Fee" value={formatBaseFee(block)} />
-                    <StatCard label="Open Capacity" value={formatOpenCapacity(block)} />
+                    <StatCard label="Blob Capacity" value={formatBlobCapacity(block)} />
                   </div>
                 </div>
 

--- a/src/components/LatestBlocksTable.test.tsx
+++ b/src/components/LatestBlocksTable.test.tsx
@@ -95,6 +95,7 @@ describe('LatestBlocksTable', () => {
   it('does not auto-expand a block row on initial load', () => {
     render(<LatestBlocksTable />);
 
+    expect(screen.getByText('1/6 used')).toBeInTheDocument();
     expect(screen.queryByText('Blob details')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'View blob details for block 200' }));

--- a/src/components/LatestBlocksTable.tsx
+++ b/src/components/LatestBlocksTable.tsx
@@ -33,9 +33,9 @@ function formatBlockBaseFee(block: Block): string {
   return formatBlobFee(block.baseFeeGwei);
 }
 
-function formatBlockOpenCapacity(block: Block): string {
+function formatBlockBlobCapacity(block: Block): string {
   if (block.maxBlobs <= 0) return '-';
-  return `${block.availableBlobs}/${block.maxBlobs} open`;
+  return `${block.blobCount}/${block.maxBlobs} used`;
 }
 
 function formatBlockUtilization(block: Block): string {
@@ -341,7 +341,7 @@ export default function LatestBlocksTable() {
                         <td className="py-3 px-3 sm:px-4 text-sm text-white">
                           <div className="whitespace-nowrap">{formatBlobCount(block.blobCount)}</div>
                           <div className="text-xs text-[#8a93a5] mt-1 whitespace-nowrap">
-                            {formatBlockOpenCapacity(block)}
+                            {formatBlockBlobCapacity(block)}
                           </div>
                           <div className="text-xs text-[#8a93a5] mt-1 whitespace-nowrap md:hidden">
                             {paidCost}


### PR DESCRIPTION
## Summary

- Rename the block detail stat from `Open Capacity` to `Blob Capacity`.
- Display blob capacity as used blobs over max blobs, e.g. `6/21 used`, instead of free slots over max slots.
- Apply the same used/max wording in the latest blocks table and add a regression assertion.

## Why

The previous copy showed `availableBlobs/maxBlobs open`, so a block with 6 used blobs and 15 open slots appeared as `15/21 open`. That made the main fraction read backwards next to the blob count and utilization percentage.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint` (passes with the existing React Compiler warning in `src/components/TopUsersTable.tsx`)
- Browser check on `http://localhost:3001/block/25177473`, which rendered `Blob Capacity` as `6/21 used`.
