### PR TITLE
feat: make the hero Above target stat follow the time range filter

### DIFF
--- a/src/components/BlobFeeHero.tsx
+++ b/src/components/BlobFeeHero.tsx
@@ -28,6 +28,9 @@ import {
   HERO_STRIP_BLOCKS,
   compareToWindows,
   computeFeeRangeTrend,
+  countBlocksAboveTarget,
+  countChartPointsAboveTarget,
+  getWindowAboveTargetSummary,
   formatFeeNumber,
   formatSignedPercent,
   mergeRecentPricingBlocks,
@@ -166,6 +169,14 @@ const TREND_CHIP_LABELS: Record<TimeRange, string> = {
   '7d': '7d',
   '30d': '30d',
   All: '30d',
+};
+
+/** Unit shown under the "Above target" count for bucketed ranges. */
+const BUCKET_HINTS: Record<string, string> = {
+  block: 'block buckets',
+  minute: 'minute buckets',
+  hour: 'hourly buckets',
+  day: 'daily buckets',
 };
 
 function isDayScaleRange(timeRange: TimeRange): boolean {
@@ -540,10 +551,15 @@ export default function BlobFeeHero() {
       : currentFeeGwei > previousFeeGwei
         ? 'animate-[fee-tick-up_900ms_ease-out]'
         : 'animate-[fee-tick-down_900ms_ease-out]';
+
+  const rollingWindows = useMemo(
+    () => (statsWindows ? transformStatsWindows(statsWindows) : []),
+    [statsWindows]
+  );
   const comparisons = useMemo(() => {
-    if (!statsWindows || currentFeeGwei <= 0) return [];
-    return compareToWindows(currentFeeGwei, transformStatsWindows(statsWindows));
-  }, [statsWindows, currentFeeGwei]);
+    if (currentFeeGwei <= 0) return [];
+    return compareToWindows(currentFeeGwei, rollingWindows);
+  }, [rollingWindows, currentFeeGwei]);
   const oneHourAverageGwei = comparisons.find((comparison) => comparison.window === '1h')?.averageGwei;
 
   const chartPoints = useMemo<HeroChartPoint[]>(() => {
@@ -583,6 +599,34 @@ export default function BlobFeeHero() {
       : undefined;
 
   const stripBlocks = useMemo(() => blocks.slice(0, HERO_STRIP_BLOCKS), [blocks]);
+
+  // "Above target" follows the header time range: per-block counts on the
+  // live 1h view; on 24h/7d/30d/All, true block counts from the stats window
+  // when the backend provides them, otherwise range-chart bucket counts.
+  const aboveTargetStat = useMemo(() => {
+    if (isLiveRange) {
+      const live = countBlocksAboveTarget(blocks);
+      return { value: `${live.aboveCount}/${live.totalCount}`, hint: 'recent blocks' };
+    }
+    const windowSummary = getWindowAboveTargetSummary(
+      rollingWindows,
+      getRequestedRollingWindow(timeRange)
+    );
+    if (windowSummary) {
+      return {
+        value: `${windowSummary.aboveCount.toLocaleString()}/${windowSummary.totalCount.toLocaleString()}`,
+        hint: `blocks · ${RANGE_LABELS[timeRange]}`,
+      };
+    }
+    if (!marketChart || marketChart.points.length === 0) {
+      return { value: '—', hint: RANGE_LABELS[timeRange] };
+    }
+    const bucketed = countChartPointsAboveTarget(marketChart.points);
+    return {
+      value: `${bucketed.aboveCount}/${bucketed.totalCount}`,
+      hint: BUCKET_HINTS[marketChart.granularity] ?? `${marketChart.granularity} buckets`,
+    };
+  }, [isLiveRange, blocks, rollingWindows, marketChart, timeRange]);
 
   const direction = getDirectionStyle(rangeTrend?.direction);
   const DirectionIcon = direction.Icon;
@@ -679,8 +723,8 @@ export default function BlobFeeHero() {
                 <div className="mt-5 grid grid-cols-2 gap-x-4 gap-y-3 border-t border-divider pt-4 sm:grid-cols-4 lg:grid-cols-2 xl:grid-cols-4">
                   <PressureStat
                     label="Above target"
-                    value={`${pricing.marketPressure.recentBlocksAboveTarget}/${pricing.recentBlocks.length}`}
-                    hint="recent blocks"
+                    value={aboveTargetStat.value}
+                    hint={aboveTargetStat.hint}
                   />
                   <PressureStat
                     label="Full streak"

--- a/src/lib/blobFeeHero.test.ts
+++ b/src/lib/blobFeeHero.test.ts
@@ -3,12 +3,19 @@ import {
   compareToWindows,
   computeFeeRangeTrend,
   computeFeeTrend,
+  countBlocksAboveTarget,
+  countChartPointsAboveTarget,
+  getWindowAboveTargetSummary,
   formatFeeNumber,
   formatSignedPercent,
   mergeRecentPricingBlocks,
   parseGwei,
 } from './blobFeeHero';
-import type { BlobPricingRecentBlock, RollingWindowDataPoint } from '@/types';
+import type {
+  BackendBlobMarketChartPoint,
+  BlobPricingRecentBlock,
+  RollingWindowDataPoint,
+} from '@/types';
 
 function makeBlock(
   blockNumber: number,
@@ -37,7 +44,8 @@ function makeBlock(
 
 function makeWindow(
   window: string,
-  averageBaseFeeGwei: number
+  averageBaseFeeGwei: number,
+  overrides: Partial<RollingWindowDataPoint> = {}
 ): RollingWindowDataPoint {
   return {
     window,
@@ -53,8 +61,89 @@ function makeWindow(
     averageUtilizationPct: 50,
     totalCostEth: 1,
     uniqueSenders: 5,
+    ...overrides,
   };
 }
+
+function makeChartPoint(
+  overrides: Partial<BackendBlobMarketChartPoint> = {}
+): BackendBlobMarketChartPoint {
+  return {
+    timestamp: '2026-06-11T00:00:00Z',
+    average_blob_base_fee_gwei: '0.01',
+    median_blob_base_fee_gwei: '0.01',
+    p95_blob_base_fee_gwei: '0.01',
+    blob_count: 4,
+    blob_gas_used: 524288,
+    blob_gas_target: 1835008,
+    average_utilization: '0.19',
+    total_cost_wei: '0',
+    unique_senders: 1,
+    ...overrides,
+  };
+}
+
+describe('countBlocksAboveTarget', () => {
+  it('counts blocks flagged above target', () => {
+    const blocks = [
+      makeBlock(3, { isAboveTarget: true }),
+      makeBlock(2),
+      makeBlock(1, { isAboveTarget: true }),
+    ];
+
+    expect(countBlocksAboveTarget(blocks)).toEqual({ aboveCount: 2, totalCount: 3 });
+    expect(countBlocksAboveTarget([])).toEqual({ aboveCount: 0, totalCount: 0 });
+  });
+});
+
+describe('getWindowAboveTargetSummary', () => {
+  it('returns block counts for the matching window', () => {
+    const windows = [
+      makeWindow('1h', 0.01, { totalBlocks: 300, blocksAboveTarget: 120 }),
+      makeWindow('24h', 0.01, { totalBlocks: 7200, blocksAboveTarget: 4812 }),
+    ];
+
+    expect(getWindowAboveTargetSummary(windows, '24h')).toEqual({
+      aboveCount: 4812,
+      totalCount: 7200,
+    });
+  });
+
+  it('returns null when the window is missing or lacks block counts', () => {
+    const windows = [
+      makeWindow('24h', 0.01),
+      makeWindow('7d', 0.01, { totalBlocks: 0, blocksAboveTarget: 0 }),
+      makeWindow('30d', 0.01, { totalBlocks: 1000 }),
+    ];
+
+    // Backend predates the block-count fields.
+    expect(getWindowAboveTargetSummary(windows, '24h')).toBeNull();
+    // No blocks indexed in the window.
+    expect(getWindowAboveTargetSummary(windows, '7d')).toBeNull();
+    // Only one of the two fields present.
+    expect(getWindowAboveTargetSummary(windows, '30d')).toBeNull();
+    // Window not requested/returned.
+    expect(getWindowAboveTargetSummary(windows, '1h')).toBeNull();
+  });
+});
+
+describe('countChartPointsAboveTarget', () => {
+  it('counts buckets whose gas usage exceeds the bucket target', () => {
+    const points = [
+      makeChartPoint({ blob_gas_used: 2_000_000, blob_gas_target: 1_835_008 }),
+      makeChartPoint({ blob_gas_used: 524_288, blob_gas_target: 1_835_008 }),
+      makeChartPoint({ blob_gas_used: 1_835_008, blob_gas_target: 1_835_008 }),
+    ];
+
+    expect(countChartPointsAboveTarget(points)).toEqual({ aboveCount: 1, totalCount: 3 });
+  });
+
+  it('never marks a bucket without a target as above it', () => {
+    const points = [makeChartPoint({ blob_gas_used: 100, blob_gas_target: 0 })];
+
+    expect(countChartPointsAboveTarget(points)).toEqual({ aboveCount: 0, totalCount: 1 });
+  });
+});
 
 describe('mergeRecentPricingBlocks', () => {
   it('merges fetched and live blocks newest-first without duplicates', () => {

--- a/src/lib/blobFeeHero.ts
+++ b/src/lib/blobFeeHero.ts
@@ -1,4 +1,8 @@
-import type { BlobPricingRecentBlock, RollingWindowDataPoint } from '@/types';
+import type {
+  BackendBlobMarketChartPoint,
+  BlobPricingRecentBlock,
+  RollingWindowDataPoint,
+} from '@/types';
 
 /** Number of recent blocks shown in the hero fee chart (~20 min of mainnet blocks). */
 export const HERO_CHART_BLOCKS = 100;
@@ -32,6 +36,57 @@ export function mergeRecentPricingBlocks(
   return Array.from(byNumber.values())
     .sort((left, right) => right.blockNumber - left.blockNumber)
     .slice(0, cap);
+}
+
+export interface AboveTargetSummary {
+  aboveCount: number;
+  totalCount: number;
+}
+
+/** Count blocks flagged above the per-block blob target (live 1h hero view). */
+export function countBlocksAboveTarget(blocks: BlobPricingRecentBlock[]): AboveTargetSummary {
+  return {
+    aboveCount: blocks.filter((block) => block.isAboveTarget).length,
+    totalCount: blocks.length,
+  };
+}
+
+/**
+ * Block-level above-target counts for a rolling window, when the stats API
+ * provides them (`total_blocks`/`blocks_above_target`). Returns null when the
+ * window is missing or the backend predates those fields, so callers can fall
+ * back to bucket counting.
+ */
+export function getWindowAboveTargetSummary(
+  windows: RollingWindowDataPoint[],
+  windowKey: string
+): AboveTargetSummary | null {
+  const match = windows.find((window) => window.window === windowKey);
+  if (
+    !match ||
+    match.totalBlocks === undefined ||
+    match.totalBlocks <= 0 ||
+    match.blocksAboveTarget === undefined
+  ) {
+    return null;
+  }
+
+  return { aboveCount: match.blocksAboveTarget, totalCount: match.totalBlocks };
+}
+
+/**
+ * Count bucketed chart points whose blob gas usage exceeds the bucket's
+ * target (24h/7d/30d hero views).
+ */
+export function countChartPointsAboveTarget(
+  points: BackendBlobMarketChartPoint[]
+): AboveTargetSummary {
+  return {
+    aboveCount: points.filter(
+      (point) => point.blob_gas_target > 0 && point.blob_gas_used > point.blob_gas_target
+    ).length,
+    totalCount: points.length,
+  };
 }
 
 export function parseGwei(value: string | number | undefined): number {

--- a/src/lib/blobFeeHero.ts
+++ b/src/lib/blobFeeHero.ts
@@ -54,8 +54,8 @@ export function countBlocksAboveTarget(blocks: BlobPricingRecentBlock[]): AboveT
 /**
  * Block-level above-target counts for a rolling window, when the stats API
  * provides them (`total_blocks`/`blocks_above_target`). Returns null when the
- * window is missing or the backend predates those fields, so callers can fall
- * back to bucket counting.
+ * window is missing, the backend predates those fields, or the window reports
+ * no indexed blocks, so callers can fall back to bucket counting.
  */
 export function getWindowAboveTargetSummary(
   windows: RollingWindowDataPoint[],

--- a/src/lib/chartAggregation.test.ts
+++ b/src/lib/chartAggregation.test.ts
@@ -165,6 +165,27 @@ describe('chartAggregation', () => {
     });
   });
 
+  it('passes block counts through and drops malformed values', () => {
+    const windows = transformStatsWindows(makeStatsWindows([
+      makeWindow('24h', 86400, { total_blocks: 7200, blocks_above_target: 4812 }),
+      makeWindow('1h', 3600, { total_blocks: Number.NaN, blocks_above_target: -1 }),
+      makeWindow('5m', 300),
+    ]));
+
+    expect(windows.find((window) => window.window === '24h')).toMatchObject({
+      totalBlocks: 7200,
+      blocksAboveTarget: 4812,
+    });
+
+    const hourWindow = windows.find((window) => window.window === '1h');
+    expect(hourWindow?.totalBlocks).toBeUndefined();
+    expect(hourWindow?.blocksAboveTarget).toBeUndefined();
+
+    const fiveMinuteWindow = windows.find((window) => window.window === '5m');
+    expect(fiveMinuteWindow?.totalBlocks).toBeUndefined();
+    expect(fiveMinuteWindow?.blocksAboveTarget).toBeUndefined();
+  });
+
   it('builds chart data from pricing blocks and selected rolling stats', () => {
     const dataset = buildChartDataset(
       makeStatsWindows([

--- a/src/lib/chartAggregation.ts
+++ b/src/lib/chartAggregation.ts
@@ -47,6 +47,11 @@ function parseFiniteNumber(value: string | number | undefined): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+/** Pass through an optional non-negative count, dropping malformed values. */
+function parseOptionalCount(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
 function decimalWeiToGwei(value: string | undefined): number {
   return roundTo(parseFiniteNumber(value) / 1e9, 6);
 }
@@ -183,6 +188,8 @@ export function transformStatsWindows(
         averageUtilizationPct: roundTo(parseFiniteNumber(window.average_utilization) * 100, 2),
         totalCostEth: weiToEth(totalCostWei),
         uniqueSenders: window.unique_senders,
+        totalBlocks: parseOptionalCount(window.total_blocks),
+        blocksAboveTarget: parseOptionalCount(window.blocks_above_target),
       };
     })
     .sort((a, b) => a.durationSeconds - b.durationSeconds);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -468,6 +468,10 @@ export interface BackendStatsWindow {
   total_cost_eth?: string;
   total_cost_wei?: string;
   unique_senders: number;
+  /** Blocks indexed within the window. Absent on older backends. */
+  total_blocks?: number;
+  /** Blocks in the window with blob gas usage above target. Absent on older backends. */
+  blocks_above_target?: number;
 }
 
 export interface BackendStatsWindowsResponse {
@@ -684,6 +688,10 @@ export interface RollingWindowDataPoint {
   averageUtilizationPct: number;
   totalCostEth: number;
   uniqueSenders: number;
+  /** Blocks indexed within the window. Absent on older backends. */
+  totalBlocks?: number;
+  /** Blocks in the window with blob gas usage above target. Absent on older backends. */
+  blocksAboveTarget?: number;
 }
 
 export interface ChartDataset {


### PR DESCRIPTION
## What changed

The "Above target" counter in the hero's pressure stats row was hardwired to the last ~100 blocks from the pricing API, so clicking the 1h/24h/7d/30d/All header filter never changed it. It now follows the selected range:

- **1h (live view):** counts the merged live block list, so it ticks in real time as WebSocket blocks land — e.g. `64/100` with hint "recent blocks".
- **24h/7d/30d/All:** resolves in priority order:
  1. True block counts from the new `total_blocks` / `blocks_above_target` fields on `/stats/windows` — e.g. `4,812/7,200` with hint "blocks · last 24h" (All uses the 30d window, matching the rest of the hero)
  2. Fallback for backends without those fields: counts range-chart buckets where `blob_gas_used > blob_gas_target` — e.g. `14/24` with hint "hourly buckets"
  3. `—` while neither source has loaded

## Why

Clicking the time range filter should change the hero's above-target counter (it previously only affected the chart). The backend is adding `total_blocks`/`blocks_above_target` to `/stats/windows`; this wires the frontend to prefer those true block counts while degrading gracefully against older backends, so frontend and backend can deploy in either order.

## Notes for reviewers

- Counting and window-selection logic lives in pure helpers (`countBlocksAboveTarget`, `countChartPointsAboveTarget`, `getWindowAboveTargetSummary`) in `src/lib/blobFeeHero.ts`, each unit-tested, including the zero-target and missing-field edge cases.
- `transformStatsWindows` passes the new optional counts through and drops malformed values (NaN, negatives).
- The other pressure stats (Full streak, At max, Pending) intentionally stay live-only — they read as "right now" signals.
- `npm run test` (112 passed), `npm run typecheck`, and `npm run lint` are clean (one pre-existing unrelated lint warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)