### PR TITLE
fix: align hero trend labels with header ranges

### DIFF
--- a/src/components/BlobFeeHero.tsx
+++ b/src/components/BlobFeeHero.tsx
@@ -145,7 +145,7 @@ function stripGweiUnit(value: string): string {
 
 /** Header time ranges that the hero renders from bucketed chart data. */
 const RANGE_LABELS: Record<TimeRange, string> = {
-  '1h': 'last 100 blocks',
+  '1h': 'last 1h',
   '24h': 'last 24h',
   '7d': 'last 7 days',
   '30d': 'last 30 days',
@@ -153,7 +153,7 @@ const RANGE_LABELS: Record<TimeRange, string> = {
 };
 
 const TREND_RANGE_LABELS: Record<TimeRange, string> = {
-  '1h': 'last 100 blocks',
+  '1h': 'last 1h',
   '24h': 'last 24h',
   '7d': 'last 7 days',
   '30d': 'last 30 days',
@@ -161,7 +161,7 @@ const TREND_RANGE_LABELS: Record<TimeRange, string> = {
 };
 
 const TREND_CHIP_LABELS: Record<TimeRange, string> = {
-  '1h': '100 blocks',
+  '1h': '1h',
   '24h': '24h',
   '7d': '7d',
   '30d': '30d',
@@ -709,7 +709,7 @@ export default function BlobFeeHero() {
                 <div className="mb-2 flex flex-wrap items-center justify-between gap-2 text-[11px] text-[#6e7687]">
                   <span>
                     {isLiveRange
-                      ? `Blob base fee · last ${blocks.length} blocks`
+                      ? `Blob base fee · ${RANGE_LABELS[timeRange]}`
                       : `Avg blob base fee · ${RANGE_LABELS[timeRange]}`}
                   </span>
                   {headBlock && (

--- a/src/components/TopUsersTable.tsx
+++ b/src/components/TopUsersTable.tsx
@@ -162,7 +162,7 @@ export default function TopUsersTable() {
                   <CircleHelp className="h-3.5 w-3.5" aria-hidden="true" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Last 100 blocks</TooltipContent>
+              <TooltipContent>Recent indexed activity</TooltipContent>
             </Tooltip>
           </div>
         ),


### PR DESCRIPTION
## Summary
- Replace the default hero trend wording with the selected `1h` range instead of exposing the internal block cap.
- Keep the live hero chart caption aligned with the header range labels.
- Remove the remaining `Last 100 blocks` tooltip copy from the top users table.

## Why
The default header filter is `1h`, so showing `100 blocks` made the UI feel like it supported a separate hidden range. This keeps all visible range language aligned with the header options.

## Validation
- `npm run test -- src/lib/blobFeeHero.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with an existing `TopUsersTable.tsx:196` React Compiler warning)
- `rg -n "100 blocks|last 100|last \\${blocks.length} blocks|[0-9]+ blocks" src/components src/lib` returns no matches
