### PR TITLE
feat: show blob gas max capacity line

### DIFF
--- a/src/components/charts/GasUtilizationChart.tsx
+++ b/src/components/charts/GasUtilizationChart.tsx
@@ -35,9 +35,11 @@ function formatGas(value: number): string {
 
 export default function GasUtilizationChart({ data, averageUtilizationPct }: GasUtilizationChartProps) {
   const targetGas = data.find((entry) => entry.targetGas > 0)?.targetGas ?? 0;
+  const maxGas = data.find((entry) => entry.maxGas > 0)?.maxGas ?? 0;
   const averageGasUsed = targetGas > 0 && averageUtilizationPct !== undefined
     ? Math.round((targetGas * averageUtilizationPct) / 100)
     : 0;
+  const referenceMax = Math.max(targetGas, maxGas, averageGasUsed);
 
   return (
     <ResponsiveContainer width="100%" height="100%">
@@ -59,6 +61,13 @@ export default function GasUtilizationChart({ data, averageUtilizationPct }: Gas
           tickLine={AXIS_LINE}
           width={45}
           tickFormatter={formatGas}
+          domain={[
+            0,
+            (dataMax: number) => {
+              const maxValue = Math.max(dataMax, referenceMax);
+              return maxValue > 0 ? Math.ceil(maxValue * 1.08) : 1;
+            },
+          ]}
         />
         <Tooltip
           contentStyle={CHART_TOOLTIP_STYLE}
@@ -82,6 +91,11 @@ export default function GasUtilizationChart({ data, averageUtilizationPct }: Gas
                 <p style={{ color: '#6e7687', fontSize: '12px' }}>
                   Target: {formatGas(d.targetGas)}
                 </p>
+                {d.maxGas > 0 && (
+                  <p style={{ color: COLORS.lightBlue, fontSize: '12px' }}>
+                    Max: {formatGas(d.maxGas)}
+                  </p>
+                )}
                 <p style={{ color: '#6e7687', fontSize: '12px' }}>
                   Blobs: {d.blobCount} ({d.utilizationPct}%)
                 </p>
@@ -96,6 +110,15 @@ export default function GasUtilizationChart({ data, averageUtilizationPct }: Gas
             strokeDasharray="5 5"
             strokeOpacity={0.7}
             label={{ value: 'Target', fill: '#6e7687', fontSize: 10, position: 'right' }}
+          />
+        )}
+        {maxGas > 0 && (
+          <ReferenceLine
+            y={maxGas}
+            stroke={COLORS.lightBlue}
+            strokeDasharray="6 4"
+            strokeOpacity={0.7}
+            label={{ value: 'Max', fill: '#6e7687', fontSize: 10, position: 'insideRight' }}
           />
         )}
         {averageGasUsed > 0 && (

--- a/src/hooks/useChartData.test.ts
+++ b/src/hooks/useChartData.test.ts
@@ -46,6 +46,7 @@ const mockMarket = {
         blob_count: 7,
         blob_gas_used: 917504,
         blob_gas_target: 1835008,
+        blob_gas_limit: 3145728,
         average_utilization: '0.5',
         total_cost_wei: '2000000000000000',
         unique_senders: 3,
@@ -282,6 +283,7 @@ describe('useChartData', () => {
     expect(result.current.chartData!.baseFee.map((point) => point.baseFeeGwei)).toEqual([1, 2]);
     expect(result.current.chartData!.gasUtilization[0].targetGas).toBe(1835008);
     expect(result.current.chartData!.gasUtilization[0].maxGas).toBe(2752512);
+    expect(result.current.chartData!.gasUtilization[1].maxGas).toBe(3145728);
     expect(result.current.chartData!.l2UsageSeries.map((series) => series.key)).toEqual(['base', 'unknown']);
     expect(result.current.chartData!.l2Usage[1].base).toBe(5);
     expect(result.current.chartData!.costComparison[0].savingsPct).toBe(99);

--- a/src/hooks/useChartData.test.ts
+++ b/src/hooks/useChartData.test.ts
@@ -281,6 +281,7 @@ describe('useChartData', () => {
     expect(result.current.timeRange).toBe('1h');
     expect(result.current.chartData!.baseFee.map((point) => point.baseFeeGwei)).toEqual([1, 2]);
     expect(result.current.chartData!.gasUtilization[0].targetGas).toBe(1835008);
+    expect(result.current.chartData!.gasUtilization[0].maxGas).toBe(2752512);
     expect(result.current.chartData!.l2UsageSeries.map((series) => series.key)).toEqual(['base', 'unknown']);
     expect(result.current.chartData!.l2Usage[1].base).toBe(5);
     expect(result.current.chartData!.costComparison[0].savingsPct).toBe(99);

--- a/src/lib/chartAggregation.test.ts
+++ b/src/lib/chartAggregation.test.ts
@@ -205,6 +205,7 @@ describe('chartAggregation', () => {
       blockNumber: 2,
       blobGasUsed: 2097152,
       targetGas: 1835008,
+      maxGas: 2752512,
       blobCount: 16,
       utilizationPct: 114,
     });

--- a/src/lib/chartAggregation.ts
+++ b/src/lib/chartAggregation.ts
@@ -79,6 +79,8 @@ function deriveMaxBlobGasFromTarget(
   const targetBlobsPerBlock = targetGasPerBlock / BLOB_GAS_PER_BLOB;
   if (!Number.isFinite(targetBlobsPerBlock) || targetBlobsPerBlock <= 0) return 0;
 
+  // Fallback for older chart payloads without `blob_gas_limit`: infer from
+  // known target/max blob schedules, such as 3->6 and 14->21 blobs.
   const maxToTargetRatio = targetBlobsPerBlock <= 3 ? 2 : 1.5;
   return Math.round(targetGas * maxToTargetRatio);
 }

--- a/src/lib/chartAggregation.ts
+++ b/src/lib/chartAggregation.ts
@@ -29,6 +29,7 @@ const WINDOW_LABELS: Record<RollingWindowKey, string> = {
 
 const WINDOW_FALLBACK_ORDER: RollingWindowKey[] = ['30d', '7d', '24h', '1h', '5m'];
 const PRICING_API_MAX_BLOCKS = 100;
+const BLOB_GAS_PER_BLOB = 131_072;
 const ESTIMATED_BLOCKS_PER_RANGE: Record<TimeRange, number> = {
   '1h': 300,
   '24h': 7_200,
@@ -50,6 +51,36 @@ function parseFiniteNumber(value: string | number | undefined): number {
 /** Pass through an optional non-negative count, dropping malformed values. */
 function parseOptionalCount(value: number | undefined): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function getInclusiveBlockCount(startBlock?: number, endBlock?: number): number {
+  if (
+    startBlock === undefined ||
+    endBlock === undefined ||
+    !Number.isFinite(startBlock) ||
+    !Number.isFinite(endBlock) ||
+    endBlock < startBlock
+  ) {
+    return 0;
+  }
+
+  return endBlock - startBlock + 1;
+}
+
+function deriveMaxBlobGasFromTarget(
+  targetGas: number,
+  startBlock?: number,
+  endBlock?: number
+): number {
+  if (!Number.isFinite(targetGas) || targetGas <= 0) return 0;
+
+  const blockCount = getInclusiveBlockCount(startBlock, endBlock);
+  const targetGasPerBlock = blockCount > 0 ? targetGas / blockCount : targetGas;
+  const targetBlobsPerBlock = targetGasPerBlock / BLOB_GAS_PER_BLOB;
+  if (!Number.isFinite(targetBlobsPerBlock) || targetBlobsPerBlock <= 0) return 0;
+
+  const maxToTargetRatio = targetBlobsPerBlock <= 3 ? 2 : 1.5;
+  return Math.round(targetGas * maxToTargetRatio);
 }
 
 function decimalWeiToGwei(value: string | undefined): number {
@@ -257,6 +288,7 @@ export function transformPricingBlocks(pricing: BlobPricing): {
       blockNumber: block.blockNumber,
       blobGasUsed: block.blobGasUsed,
       targetGas,
+      maxGas: block.blobGasLimit || pricing.blobParams.maxGas,
       blobCount: block.blobCount,
       utilizationPct,
     };
@@ -352,19 +384,28 @@ function transformMarketPoints(market: BackendBlobMarketChartResponse): {
     blockNumber: point.end_block,
   }));
 
-  const gasUtilization = sortedPoints.map((point) => ({
-    timestamp: isoTimestamp(point.timestamp),
-    label: point.label ?? (
-      market.granularity === 'block' && point.end_block
-        ? `#${point.end_block}`
-        : formatBucketLabel(point.timestamp, market.granularity)
-    ),
-    blockNumber: point.end_block ?? point.start_block ?? 0,
-    blobGasUsed: point.blob_gas_used,
-    targetGas: point.blob_gas_target,
-    blobCount: point.blob_count,
-    utilizationPct: roundTo(parseFiniteNumber(point.average_utilization) * 100, 0),
-  }));
+  const gasUtilization = sortedPoints.map((point) => {
+    const explicitMaxGas = parseFiniteNumber(point.blob_gas_limit);
+    const maxGas =
+      explicitMaxGas > 0
+        ? explicitMaxGas
+        : deriveMaxBlobGasFromTarget(point.blob_gas_target, point.start_block, point.end_block);
+
+    return {
+      timestamp: isoTimestamp(point.timestamp),
+      label: point.label ?? (
+        market.granularity === 'block' && point.end_block
+          ? `#${point.end_block}`
+          : formatBucketLabel(point.timestamp, market.granularity)
+      ),
+      blockNumber: point.end_block ?? point.start_block ?? 0,
+      blobGasUsed: point.blob_gas_used,
+      targetGas: point.blob_gas_target,
+      maxGas,
+      blobCount: point.blob_count,
+      utilizationPct: roundTo(parseFiniteNumber(point.average_utilization) * 100, 0),
+    };
+  });
 
   return { baseFee, gasUtilization };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -507,6 +507,7 @@ export interface BackendBlobMarketChartPoint {
   blob_count: number;
   blob_gas_used: number;
   blob_gas_target: number;
+  blob_gas_limit?: number;
   average_utilization: string;
   total_cost_wei: string;
   unique_senders: number;
@@ -638,6 +639,7 @@ export interface GasUtilizationDataPoint {
   blockNumber: number;
   blobGasUsed: number;
   targetGas: number;
+  maxGas: number;
   blobCount: number;
   utilizationPct: number;
 }


### PR DESCRIPTION
## Summary

- add max-capacity data to blob gas utilization chart points
- render a light-blue Max reference line alongside Target and Avg
- include max capacity in the utilization tooltip and preserve Y-axis headroom

## Validation

- npm test -- --run src/lib/chartAggregation.test.ts src/hooks/useChartData.test.ts
- npm run typecheck
- npm run lint (passes with existing react-hooks/incompatible-library warning in src/components/TopUsersTable.tsx)
- Browser smoke check confirmed the 7d chart renders Target, Max, and Avg lines
